### PR TITLE
chore: update deps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,9 @@ hs_err_pid*
 
 # Maven build directory
 target/
+
+.claude
+
+.mvn
+
+.vscode

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -1,0 +1,26 @@
+# Compatibility
+
+## Release lines
+
+- `BlockParty 3.x`
+  - Status: active modern line
+  - Java: `21+`
+  - Minecraft server support: `1.20.6+`, `1.21.x`
+  - Build target: modern shaded jar with `spigot_v1_20_R1` and `spigot_v1_21_R1`
+- `BlockParty 2.x`
+  - Status: legacy line
+  - Java: pre-modern baseline
+  - Minecraft server support: `1.8` through `1.19.x`
+  - Notes: keep this branch or its final release available for older networks
+
+## Verification checklist
+
+- Build with `mvn -DskipTests package`
+- Boot on a `1.20.6` server and confirm:
+  - plugin load, enable, disable
+  - arena join, leave, start, stop
+  - floor generation and pattern placement
+  - boosts and particle effects
+  - inventory prompts, scoreboards, titles, and action bars
+- Boot on a `1.21.x` server and confirm the same flow
+- Re-check music discs and sign interactions on both supported versions when updating the adapter modules

--- a/README.md
+++ b/README.md
@@ -1,7 +1,15 @@
-# BlockParty-2.0
+# BlockParty 3.x
 ![Jenkins](https://img.shields.io/jenkins/build/https/jenkins.simpleunity.org/job/BlockParty) [![GitHub license](https://img.shields.io/github/license/Leon167/BlockParty-2.0)](https://github.com/Leon167/BlockParty-2.0/blob/master/LICENSE) ![GitHub release](https://img.shields.io/github/release/Leon167/BlockParty-2.0)
 
-BlockParty 2 is an extension for Minecraft Servers, built with the Spigot/Bukkit API.
+BlockParty 3 is the modernized BlockParty line for current Minecraft servers, built on a Java 21 baseline with a Paper-first compatibility target.
+
+## Support policy
+
+- `BlockParty 3.x` supports `Minecraft 1.20.6+` and `1.21.x`
+- `Java 21` is required to build and run this line
+- Legacy support for `1.8` through `1.19.x` belongs on the `2.x` line
+
+See [COMPATIBILITY.md](COMPATIBILITY.md) for the runtime matrix and release split.
 
 ## Installation
 

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -14,13 +14,8 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.7.0</version>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                    <encoding>UTF-8</encoding>
-                </configuration>
             </plugin>
         </plugins>
     </build>
@@ -40,7 +35,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.8.8-R0.1-SNAPSHOT</version>
+            <version>1.17-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
 

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -3,43 +3,19 @@
          xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>blockparty-parent</artifactId>
         <groupId>de.leonkoth</groupId>
+        <artifactId>blockparty-parent</artifactId>
         <version>2.0.5-RELEASE</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>blockparty-api</artifactId>
-    <version>${project.parent.version}</version>
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-            </plugin>
-        </plugins>
-    </build>
-    <packaging>jar</packaging>
-
-    <repositories>
-        <repository>
-            <id>spigot</id>
-            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
-        </repository>
-
-    </repositories>
 
     <dependencies>
-
-        <!--Spigot API-->
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.17-R0.1-SNAPSHOT</version>
-            <scope>provided</scope>
         </dependency>
-
     </dependencies>
-
 
 </project>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>de.leonkoth</groupId>
         <artifactId>blockparty-parent</artifactId>
-        <version>2.0.5-RELEASE</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/api/src/main/java/de/leonkoth/blockparty/version/Version.java
+++ b/api/src/main/java/de/leonkoth/blockparty/version/Version.java
@@ -21,94 +21,18 @@ public class Version { // package-private
     public static final Version v1_21_4 = new Version(1, 21, 4, "v1_21_R1");
     public static final Version v1_21_1 = new Version(1, 21, 1, "v1_21_R1");
     public static final Version v1_21 = new Version(1, 21, "v1_21_R1");
-    public static final Version v1_20_6 = new Version(1, 20, 6, "v1_20_R4");
-    public static final Version v1_20_4 = new Version(1, 20, 4, "v1_20_R3");
-    public static final Version v1_20_2 = new Version(1, 20, 2, "v1_20_R2");
+    public static final Version v1_20_6 = new Version(1, 20, 6, "v1_20_R1");
+    public static final Version v1_20_4 = new Version(1, 20, 4, "v1_20_R1");
+    public static final Version v1_20_2 = new Version(1, 20, 2, "v1_20_R1");
     public static final Version v1_20_1 = new Version(1, 20, 1, "v1_20_R1");
     public static final Version v1_20 = new Version(1, 20, "v1_20_R1");
-    public static final Version v1_19_4 = new Version(1, 19, 4, "v1_19_R3");
-    public static final Version v1_19_3 = new Version(1, 19, 3, "v1_19_R3");
-    public static final Version v1_19_2 = new Version(1, 19, 2, "v1_19_R2");
-    public static final Version v1_19_1 = new Version(1, 19, 1, "v1_19_R1");
-    public static final Version v1_19 = new Version(1, 19, "v1_19_R1");
-    public static final Version v1_18_2 = new Version(1, 18, 2, "v1_18_R2");
-    public static final Version v1_18_1 = new Version(1, 18, 1, "v1_18_R1");
-    public static final Version v1_18 = new Version(1, 18, "v1_18_R1");
-    public static final Version v1_17 = new Version(1, 17, "v1_17_R1");
-    public static final Version v1_16_5 = new Version(1, 16, 5, "v1_16_R3");
-    public static final Version v1_16_4 = new Version(1, 16, 4, "v1_16_R3");
-    public static final Version v1_16_3 = new Version(1, 16, 3, "v1_16_R2");
-    public static final Version v1_16_2 = new Version(1, 16, 2, "v1_16_R2");
-    public static final Version v1_16_1 = new Version(1, 16, 1, "v1_16_R1");
-    public static final Version v1_15_2 = new Version(1, 15, 2, "v1_15_R1");
-    public static final Version v1_15_1 = new Version(1, 15, 1, "v1_15_R1");
-    public static final Version v1_15 = new Version(1, 15, "v1_15_R1");
-    public static final Version v1_14_4 = new Version(1, 14, 4, "v1_14_R1");
-    public static final Version v1_14_3 = new Version(1, 14, 3, "v1_14_R1");
-    public static final Version v1_14_2 = new Version(1, 14, 2, "v1_14_R1");
-    public static final Version v1_14_1 = new Version(1, 14, 1, "v1_14_R1");
-    public static final Version v1_14 = new Version(1, 14, "v1_14_R1");
-    public static final Version v1_13_2 = new Version(1, 13, 2, "v1_13_R2");
-    public static final Version v1_13_1 = new Version(1, 13, 1, "v1_13_R2");
-    public static final Version v1_13 = new Version(1, 13, "v1_13_R1");
-    public static final Version v1_12_2 = new Version(1, 12, 2, "v1_12_R1");
-    public static final Version v1_12_1 = new Version(1, 12, 1, "v1_12_R1");
-    public static final Version v1_12 = new Version(1, 12, "v1_12_R1");
-    public static final Version v1_11_2 = new Version(1, 11, 2, "v1_11_R1");
-    public static final Version v1_11_1 = new Version(1, 11, 1, "v1_11_R1");
-    public static final Version v1_11 = new Version(1, 11, "v1_11_R1");
-    public static final Version v1_10_2 = new Version(1, 10, 2, "v1_10_R1");
-    public static final Version v1_10_1 = new Version(1, 10, 1, "v1_10_R1");
-    public static final Version v1_10 = new Version(1, 10, "v1_10_R1");
-    public static final Version v1_9_4 = new Version(1, 9, 4, "v1_9_R2");
-    public static final Version v1_9_3 = new Version(1, 9, 3, "v1_9_R1");
-    public static final Version v1_9_2 = new Version(1, 9, 2, "v1_9_R1");
-    public static final Version v1_9_1 = new Version(1, 9, 1, "v1_9_R1");
-    public static final Version v1_9 = new Version(1, 9, "v1_9_R1");
-    public static final Version v1_8_9 = new Version(1, 8, 9, "v1_8_R3");
-    public static final Version v1_8_8 = new Version(1, 8, 8, "v1_8_R3");
-    public static final Version v1_8_7 = new Version(1, 8, 7, "v1_8_R3");
-    public static final Version v1_8_6 = new Version(1, 8, 6, "v1_8_R3");
-    public static final Version v1_8_5 = new Version(1, 8, 5, "v1_8_R3");
-    public static final Version v1_8_4 = new Version(1, 8, 4, "v1_8_R3");
-    public static final Version v1_8_3 = new Version(1, 8, 3, "v1_8_R2");
-    public static final Version v1_8_2 = new Version(1, 8, 2, "v1_8_R1");
-    public static final Version v1_8_1 = new Version(1, 8, 1, "v1_8_R1");
-    public static final Version v1_8 = new Version(1, 8, "v1_8_R1");
-    public static final Version v1_7_10 = new Version(1, 7, 10);
-    public static final Version v1_7_9 = new Version(1, 7, 9);
-    public static final Version v1_7_8 = new Version(1, 7, 8);
-    public static final Version v1_7_7 = new Version(1, 7, 7);
-    public static final Version v1_7_6 = new Version(1, 7, 6);
-    public static final Version v1_7_5 = new Version(1, 7, 5);
-    public static final Version v1_7_4 = new Version(1, 7, 4);
-    public static final Version v1_7_2 = new Version(1, 7, 2);
     //endregion
 
     public static List<Version> versionList = new ArrayList<>();
 
     static {
         versionList.add(v1_21);
-        versionList.add(v1_20_4);
-        versionList.add(v1_20);
-        versionList.add(v1_19_3);
-        versionList.add(v1_19);
-        versionList.add(v1_18_2);
-        versionList.add(v1_18);
-        versionList.add(v1_16_5);
-        versionList.add(v1_16_1);
-        versionList.add(v1_15);
-        versionList.add(v1_14);
-        versionList.add(v1_13_1);
-        versionList.add(v1_13);
-        versionList.add(v1_12);
-        versionList.add(v1_11);
-        versionList.add(v1_10);
-        versionList.add(v1_9_4);
-        versionList.add(v1_9);
-        versionList.add(v1_8_4);
-        versionList.add(v1_8_3);
-        versionList.add(v1_8);
+        versionList.add(v1_20_6);
     }
 
     @Getter
@@ -156,11 +80,14 @@ public class Version { // package-private
      */
     public Version() {
         String[] split = Bukkit.getBukkitVersion().split("-")[0].split("\\.");
-        String pack = Bukkit.getServer().getClass().getPackage().getName();
-        this.version = pack.substring(pack.lastIndexOf('.') + 1);
         this.major = 1;
         this.minor = Integer.parseInt(split[1]);
         this.patch = split.length > 2 ? Integer.parseInt(split[2]) : 0;
+        this.version = resolveModuleVersion(this.minor);
+    }
+
+    private static String resolveModuleVersion(int minor) {
+        return minor >= 21 ? "v1_21_R1" : "v1_20_R1";
     }
 
     /**

--- a/api/src/main/java/de/leonkoth/blockparty/version/Version.java
+++ b/api/src/main/java/de/leonkoth/blockparty/version/Version.java
@@ -18,6 +18,22 @@ public class Version { // package-private
     public static final Version CURRENT_VERSION = new Version();
 
     //region VERSIONS
+    public static final Version v1_21_4 = new Version(1, 21, 4, "v1_21_R1");
+    public static final Version v1_21_1 = new Version(1, 21, 1, "v1_21_R1");
+    public static final Version v1_21 = new Version(1, 21, "v1_21_R1");
+    public static final Version v1_20_6 = new Version(1, 20, 6, "v1_20_R4");
+    public static final Version v1_20_4 = new Version(1, 20, 4, "v1_20_R3");
+    public static final Version v1_20_2 = new Version(1, 20, 2, "v1_20_R2");
+    public static final Version v1_20_1 = new Version(1, 20, 1, "v1_20_R1");
+    public static final Version v1_20 = new Version(1, 20, "v1_20_R1");
+    public static final Version v1_19_4 = new Version(1, 19, 4, "v1_19_R3");
+    public static final Version v1_19_3 = new Version(1, 19, 3, "v1_19_R3");
+    public static final Version v1_19_2 = new Version(1, 19, 2, "v1_19_R2");
+    public static final Version v1_19_1 = new Version(1, 19, 1, "v1_19_R1");
+    public static final Version v1_19 = new Version(1, 19, "v1_19_R1");
+    public static final Version v1_18_2 = new Version(1, 18, 2, "v1_18_R2");
+    public static final Version v1_18_1 = new Version(1, 18, 1, "v1_18_R1");
+    public static final Version v1_18 = new Version(1, 18, "v1_18_R1");
     public static final Version v1_17 = new Version(1, 17, "v1_17_R1");
     public static final Version v1_16_5 = new Version(1, 16, 5, "v1_16_R3");
     public static final Version v1_16_4 = new Version(1, 16, 4, "v1_16_R3");
@@ -72,6 +88,15 @@ public class Version { // package-private
     public static List<Version> versionList = new ArrayList<>();
 
     static {
+        versionList.add(v1_21);
+        versionList.add(v1_20_4);
+        versionList.add(v1_20);
+        versionList.add(v1_19_3);
+        versionList.add(v1_19);
+        versionList.add(v1_18_2);
+        versionList.add(v1_18);
+        versionList.add(v1_16_5);
+        versionList.add(v1_16_1);
         versionList.add(v1_15);
         versionList.add(v1_14);
         versionList.add(v1_13_1);

--- a/api/src/main/java/de/leonkoth/blockparty/version/VersionHandler.java
+++ b/api/src/main/java/de/leonkoth/blockparty/version/VersionHandler.java
@@ -10,7 +10,7 @@ public class VersionHandler {
 
     public static void init() {
 
-        blockPlacer = (IBlockPlacer) load("BlockPlacer", IBlockPlacer.class);
+        blockPlacer = load("BlockPlacer", IBlockPlacer.class);
 
         if(blockPlacer != null) {
             Bukkit.getConsoleSender().sendMessage("§a[BlockParty] Loading VersionedMaterial.");
@@ -19,7 +19,7 @@ public class VersionHandler {
 
     }
 
-    public static Object load(String className, Class<?> classI)
+    public static <T> T load(String className, Class<T> classI)
     {
         Version currentVersion = Version.CURRENT_VERSION;
         int i = 0;
@@ -46,35 +46,22 @@ public class VersionHandler {
             currentVersion = Version.versionList.get(i);
         }
 
-        Object obj = null;
-        boolean isBlockPartyMaterial = false;
-        if (classI == BlockPartyMaterial.class)
-            isBlockPartyMaterial = true;
+        T obj = null;
 
         while (obj == null && i < Version.versionList.size()) {
             try {
-                Class<?> clazz = Class.forName("de.leonkoth.blockparty.version." + currentVersion.getVersion() + "." + className);
-                if (!classI.isAssignableFrom(clazz)) {
-                    throw new RuntimeException("Incompatible class: " + clazz.getName());
-                } else {
-                    if(isBlockPartyMaterial) {
-                        Class<? extends BlockPartyMaterial> dynClass = (Class<? extends BlockPartyMaterial>) clazz;
-                        obj = dynClass.newInstance();
-                    } else {
-                        Class<? extends IBlockPlacer> dynClass = (Class<? extends IBlockPlacer>) clazz;
-                        obj = dynClass.newInstance();
-                    }
+                Class<? extends T> clazz = Class.forName(
+                        "de.leonkoth.blockparty.version." + currentVersion.getVersion() + "." + className
+                ).asSubclass(classI);
+                obj = clazz.getDeclaredConstructor().newInstance();
+            } catch (ClassNotFoundException e) {
+                i++;
+                if (i >= Version.versionList.size()) {
+                    break;
                 }
+                currentVersion = Version.versionList.get(i);
+                continue;
             } catch (ReflectiveOperationException e) {
-                if (e instanceof ClassNotFoundException) {
-                    i++;
-                    if (i >= Version.versionList.size()) {
-                        break;
-                    }
-                    currentVersion = Version.versionList.get(i);
-                    continue;
-                }
-
                 e.printStackTrace();
             }
         }

--- a/api/src/main/java/de/leonkoth/blockparty/version/VersionHandler.java
+++ b/api/src/main/java/de/leonkoth/blockparty/version/VersionHandler.java
@@ -35,6 +35,17 @@ public class VersionHandler {
         }
 
 
+        // On 1.17+ the CraftBukkit package no longer carries a version suffix, so
+        // currentVersion.getVersion() returns "craftbukkit" rather than e.g. "v1_16_R3".
+        // In that case skip the exact-match attempt and start directly at the first
+        // versionList entry that is <= the running version.
+        boolean hasNmsVersion = currentVersion.getVersion() != null
+                && currentVersion.getVersion().startsWith("v");
+
+        if (!hasNmsVersion && i < Version.versionList.size()) {
+            currentVersion = Version.versionList.get(i);
+        }
+
         Object obj = null;
         boolean isBlockPartyMaterial = false;
         if (classI == BlockPartyMaterial.class)

--- a/api/src/main/java/de/leonkoth/blockparty/version/VersionHandler.java
+++ b/api/src/main/java/de/leonkoth/blockparty/version/VersionHandler.java
@@ -51,7 +51,7 @@ public class VersionHandler {
         if (classI == BlockPartyMaterial.class)
             isBlockPartyMaterial = true;
 
-        while (obj == null && currentVersion.isGreaterOrEquals(Version.v1_8_4)) {
+        while (obj == null && i < Version.versionList.size()) {
             try {
                 Class<?> clazz = Class.forName("de.leonkoth.blockparty.version." + currentVersion.getVersion() + "." + className);
                 if (!classI.isAssignableFrom(clazz)) {
@@ -68,6 +68,9 @@ public class VersionHandler {
             } catch (ReflectiveOperationException e) {
                 if (e instanceof ClassNotFoundException) {
                     i++;
+                    if (i >= Version.versionList.size()) {
+                        break;
+                    }
                     currentVersion = Version.versionList.get(i);
                     continue;
                 }

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -3,21 +3,15 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>blockparty-parent</artifactId>
         <groupId>de.leonkoth</groupId>
+        <artifactId>blockparty-parent</artifactId>
         <version>2.0.5-RELEASE</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>blockparty-core</artifactId>
-    <version>${project.parent.version}</version>
-    <packaging>jar</packaging>
 
     <repositories>
-        <repository>
-            <id>spigot</id>
-            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
-        </repository>
         <repository>
             <id>jitpack.io</id>
             <url>https://jitpack.io</url>
@@ -29,123 +23,68 @@
     </repositories>
 
     <dependencies>
-        
-        <!--Spigot API-->
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
             <version>1.15.2-R0.1-SNAPSHOT</version>
-            <scope>provided</scope>
         </dependency>
-
-        <dependency>
-            <groupId>org.bukkit</groupId>
-            <artifactId>bukkit</artifactId>
-            <version>1.15.2-R0.1-SNAPSHOT</version>
-            <scope>provided</scope>
-        </dependency>
-
-        <!-- Java-WebSocket -->
         <dependency>
             <groupId>org.java-websocket</groupId>
             <artifactId>Java-WebSocket</artifactId>
-            <version>1.5.0</version>
-            <scope>provided</scope>
         </dependency>
-
-        <!-- https://mvnrepository.com/artifact/org.eclipse.jetty.aggregate/jetty-all -->
         <dependency>
             <groupId>org.eclipse.jetty.aggregate</groupId>
             <artifactId>jetty-all</artifactId>
-            <version>9.4.15.v20190215</version>
             <classifier>uber</classifier>
-            <scope>compile</scope>
         </dependency>
-
-        <!-- MCJukebox -->
         <dependency>
             <groupId>com.github.oliverdunk</groupId>
             <artifactId>JukeboxAPI</artifactId>
-            <version>v2.5.3</version>
-            <scope>provided</scope>
         </dependency>
-
-        <!-- NoteBlockAPI -->
         <dependency>
             <groupId>com.github.koca2000</groupId>
             <artifactId>NoteBlockAPI</artifactId>
-            <version>1.6.1</version>
-            <scope>provided</scope>
         </dependency>
-
-        <!-- bStats -->
         <dependency>
             <groupId>org.bstats</groupId>
             <artifactId>bstats-bukkit</artifactId>
-            <version>1.7</version>
-            <scope>compile</scope>
         </dependency>
-
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
-            <version>3.0.2</version>
-            <scope>provided</scope>
         </dependency>
-
         <dependency>
             <groupId>cloud.timo.timocloud</groupId>
             <artifactId>TimoCloud-API</artifactId>
-            <version>6.7.9</version>
-            <scope>provided</scope>
         </dependency>
-
         <dependency>
             <groupId>de.leonkoth</groupId>
             <artifactId>blockparty-utils</artifactId>
-            <version>${project.parent.version}</version>
             <scope>provided</scope>
         </dependency>
-
         <dependency>
             <groupId>de.leonkoth</groupId>
             <artifactId>blockparty-api</artifactId>
-            <version>${project.parent.version}</version>
             <scope>provided</scope>
         </dependency>
-
     </dependencies>
-
 
     <build>
         <plugins>
-            <!-- Compiler -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-            </plugin>
-
-            <!-- Shade JAR -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.1.0</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
-                        <goals>
-                            <goal>shade</goal>
-                        </goals>
+                        <goals><goal>shade</goal></goals>
                         <configuration>
                             <filters>
                                 <filter>
                                     <artifact>*:*</artifact>
-                                    <excludes>
-                                        <exclude>META-INF/**</exclude>
-                                    </excludes>
+                                    <excludes><exclude>META-INF/**</exclude></excludes>
                                 </filter>
                             </filters>
-
                             <minimizeJar>true</minimizeJar>
                             <relocations>
                                 <relocation>
@@ -158,14 +97,10 @@
                     </execution>
                 </executions>
             </plugin>
-
-            <!-- Build Jar -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.0.2</version>
             </plugin>
-
         </plugins>
 
         <resources>
@@ -174,7 +109,6 @@
                 <filtering>true</filtering>
             </resource>
         </resources>
-
     </build>
 
 </project>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>de.leonkoth</groupId>
         <artifactId>blockparty-parent</artifactId>
-        <version>2.0.5-RELEASE</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.15.2-R0.1-SNAPSHOT</version>
+            <version>1.20.6-R0.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.java-websocket</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -23,21 +23,8 @@
             <url>https://jitpack.io</url>
         </repository>
         <repository>
-            <id>bstats-repo</id>
-            <url>http://repo.bstats.org/content/repositories/releases/</url>
-        </repository>
-        <repository>
             <id>CodeMC</id>
             <url>https://repo.codemc.org/repository/maven-public</url>
-        </repository>
-        <repository>
-            <id>sinndev-repo</id>
-            <name>Releases</name>
-            <url>http://repo.sinndev.com/content/repositories/releases/</url>
-        </repository>
-        <repository>
-            <id>TimoCloud-API</id>
-            <url>https://maven.timo.cloud/repository/TimoCloud-API/</url>
         </repository>
     </repositories>
 
@@ -71,7 +58,7 @@
             <groupId>org.eclipse.jetty.aggregate</groupId>
             <artifactId>jetty-all</artifactId>
             <version>9.4.15.v20190215</version>
-            <type>pom</type>
+            <classifier>uber</classifier>
             <scope>compile</scope>
         </dependency>
 
@@ -107,9 +94,9 @@
         </dependency>
 
         <dependency>
-            <groupId>cloud.timo.TimoCloud</groupId>
+            <groupId>cloud.timo.timocloud</groupId>
             <artifactId>TimoCloud-API</artifactId>
-            <version>5.3.1</version>
+            <version>6.7.9</version>
             <scope>provided</scope>
         </dependency>
 
@@ -136,31 +123,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.7.0</version>
-                <configuration>
-                    <source>8</source>
-                    <target>8</target>
-                    <encoding>UTF-8</encoding>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <groupId>org.projectlombok</groupId>
-                <artifactId>lombok-maven-plugin</artifactId>
-                <version>1.18.6.0</version>
-                <executions>
-                    <execution>
-                        <phase>generate-sources</phase>
-                        <goals>
-                            <goal>delombok</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <sourceDirectory>/src</sourceDirectory>
-                    <addOutputDirectory>true</addOutputDirectory>
-                    <encoding>lombok.encoding</encoding>
-                </configuration>
             </plugin>
 
             <!-- Shade JAR -->

--- a/core/src/main/java/de/leonkoth/blockparty/arena/Arena.java
+++ b/core/src/main/java/de/leonkoth/blockparty/arena/Arena.java
@@ -24,6 +24,7 @@ import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
 import org.bukkit.block.Sign;
+import org.bukkit.block.sign.Side;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Player;
 
@@ -211,7 +212,6 @@ public class Arena {
                 playerInfo.setCurrentArena(this);
                 player.getInventory().setItem(8, ItemType.LEAVEARENA.getItem());
                 player.getInventory().setItem(7, ItemType.VOTEFORASONG.getItem());
-                player.updateInventory();
             }
         }
 
@@ -334,7 +334,8 @@ public class Arena {
                     }
                 }
                 for (int i = 0; i < 4; i++) {
-                    sign.setLine(i, lines[i]);
+                    sign.getSide(Side.FRONT).setLine(i, lines[i]);
+                    sign.getSide(Side.BACK).setLine(i, lines[i]);
                 }
 
                 sign.update();

--- a/core/src/main/java/de/leonkoth/blockparty/boost/JumpBoost.java
+++ b/core/src/main/java/de/leonkoth/blockparty/boost/JumpBoost.java
@@ -19,7 +19,7 @@ public class JumpBoost extends Boost {
 
     @Override
     public void onCollect(Location location, Player player, PlayerInfo playerInfo) {
-        player.addPotionEffect(new PotionEffect(PotionEffectType.JUMP, 200, 1));
+        player.addPotionEffect(new PotionEffect(PotionEffectType.JUMP_BOOST, 200, 1));
     }
 
     @Override

--- a/core/src/main/java/de/leonkoth/blockparty/display/DisplayScoreboard.java
+++ b/core/src/main/java/de/leonkoth/blockparty/display/DisplayScoreboard.java
@@ -4,6 +4,7 @@ import de.leonkoth.blockparty.arena.Arena;
 import de.leonkoth.blockparty.arena.ArenaState;
 import de.leonkoth.blockparty.player.PlayerInfo;
 import org.bukkit.Bukkit;
+import org.bukkit.scoreboard.Criteria;
 import org.bukkit.scoreboard.DisplaySlot;
 import org.bukkit.scoreboard.Objective;
 import org.bukkit.scoreboard.Score;
@@ -27,7 +28,7 @@ public class DisplayScoreboard {
             return;
 
         Scoreboard playerboard = Bukkit.getScoreboardManager().getNewScoreboard();
-        Objective objective = playerboard.registerNewObjective("Score", "dummy");
+        Objective objective = playerboard.registerNewObjective("Score", Criteria.DUMMY, "");
         objective.setDisplaySlot(DisplaySlot.SIDEBAR);
         objective.setDisplayName(SCOREBOARD_TEXT.getValue(0)
                 .replace("%LEVEL%", level + "")

--- a/core/src/main/java/de/leonkoth/blockparty/floor/Floor.java
+++ b/core/src/main/java/de/leonkoth/blockparty/floor/Floor.java
@@ -12,7 +12,6 @@ import de.leonkoth.blockparty.player.PlayerState;
 import de.leonkoth.blockparty.util.Bounds;
 import de.leonkoth.blockparty.util.ColorBlock;
 import de.leonkoth.blockparty.util.Size;
-import de.pauhull.utils.misc.MinecraftVersion;
 import de.pauhull.utils.particle.ParticlePlayer;
 import lombok.Getter;
 import lombok.Setter;
@@ -30,8 +29,6 @@ import java.io.FileNotFoundException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
-
-import static de.pauhull.utils.misc.MinecraftVersion.v1_13;
 
 /**
  * Created by Leon on 14.03.2018.
@@ -195,12 +192,10 @@ public class Floor {
     }
 
     public void removeBlocks() {
-        byte data = MinecraftVersion.CURRENT_VERSION.isLower(v1_13) ? currentBlock.getData() : 0;
         Material material = currentBlock.getType();
 
         for (Block block : getFloorBlocks()) {
-            byte floorData = MinecraftVersion.CURRENT_VERSION.isLower(v1_13) ? block.getData() : 0;
-            if (floorData != data || block.getType() != material) {
+            if (block.getType() != material) {
                 block.setType(Material.AIR);
             }
         }
@@ -237,12 +232,7 @@ public class Floor {
     }
 
     public void updateInventories(Block block) {
-        ItemStack stack;
-        if (MinecraftVersion.CURRENT_VERSION.isLower(v1_13)) {
-            stack = new ItemStack(block.getType(), 1, block.getData());
-        } else {
-            stack = new ItemStack(block.getType(), 1);
-        }
+        ItemStack stack = new ItemStack(block.getType(), 1);
         ItemMeta meta = stack.getItemMeta();
         String name = ColorBlock.get(block).getName();
         meta.setDisplayName("§f§l§o" + name);

--- a/core/src/main/java/de/leonkoth/blockparty/floor/generator/AreaGenerator.java
+++ b/core/src/main/java/de/leonkoth/blockparty/floor/generator/AreaGenerator.java
@@ -6,26 +6,17 @@ import de.leonkoth.blockparty.version.BlockInfo;
 import de.leonkoth.blockparty.version.BlockPartyMaterial;
 import de.leonkoth.blockparty.version.IBlockPlacer;
 import de.leonkoth.blockparty.version.VersionedMaterial;
-import de.pauhull.utils.misc.MinecraftVersion;
-import org.bukkit.Location;
-import org.bukkit.Material;
 
-import java.util.HashSet;
 import java.util.Random;
 import java.util.Set;
-
-import static de.pauhull.utils.misc.MinecraftVersion.v1_13;
 
 public class AreaGenerator implements FloorGenerator {
 
     private Random random = new Random();
 
-    private boolean useLegacy;
-
     private IBlockPlacer blockPlacer;
 
     public AreaGenerator() {
-        this.useLegacy = MinecraftVersion.CURRENT_VERSION.isLower(v1_13);
         this.blockPlacer = BlockParty.getInstance().getBlockPlacer();
     }
 

--- a/core/src/main/java/de/leonkoth/blockparty/listener/GameStartListener.java
+++ b/core/src/main/java/de/leonkoth/blockparty/listener/GameStartListener.java
@@ -52,7 +52,6 @@ public class GameStartListener implements Listener {
 
             player.getInventory().remove(ItemType.VOTEFORASONG.getItem());
             player.getInventory().remove(ItemType.LEAVEARENA.getItem());
-            player.updateInventory();
         }
 
         arena.broadcast(PREFIX, GAME_STARTED, false, (PlayerInfo[]) null);

--- a/core/src/main/java/de/leonkoth/blockparty/listener/PickupItemListener.java
+++ b/core/src/main/java/de/leonkoth/blockparty/listener/PickupItemListener.java
@@ -1,18 +1,11 @@
 package de.leonkoth.blockparty.listener;
 
 import de.leonkoth.blockparty.BlockParty;
-import de.pauhull.utils.misc.MinecraftVersion;
-
-import static de.pauhull.utils.misc.MinecraftVersion.v1_12;
 
 public class PickupItemListener {
 
     public PickupItemListener(BlockParty blockParty) {
-        if (MinecraftVersion.CURRENT_VERSION.isGreaterOrEquals(v1_12)) {
-            new EntityPickupItemListener(blockParty);
-        } else {
-            new PlayerPickupItemListener(blockParty);
-        }
+        new EntityPickupItemListener(blockParty);
     }
 
 }

--- a/core/src/main/java/de/leonkoth/blockparty/listener/PlayerEliminateListener.java
+++ b/core/src/main/java/de/leonkoth/blockparty/listener/PlayerEliminateListener.java
@@ -55,7 +55,6 @@ public class PlayerEliminateListener implements Listener {
             player.setGameMode(GameMode.SPECTATOR);
         player.teleport(arena.getLobbySpawn());
         player.getInventory().clear();
-        player.updateInventory();
         arena.broadcast(PREFIX, PLAYER_ELIMINATED, false, (PlayerInfo[]) null, "%PLAYER%", playerInfo.getName());
 
         if (arena.getArenaState() == ArenaState.INGAME || arena.getArenaState() == ArenaState.ENDING) {

--- a/core/src/main/java/de/leonkoth/blockparty/listener/PlayerJoinArenaListener.java
+++ b/core/src/main/java/de/leonkoth/blockparty/listener/PlayerJoinArenaListener.java
@@ -83,7 +83,6 @@ public class PlayerJoinArenaListener implements Listener {
         player.getInventory().setItem(8, ItemType.LEAVEARENA.getItem());
         if(arena.isEnableVoteItem())
             player.getInventory().setItem(7, ItemType.VOTEFORASONG.getItem());
-        player.updateInventory();
 
         this.blockParty.getDisplayScoreboard().setScoreboard(0,0,arena);
 

--- a/core/src/main/java/de/leonkoth/blockparty/phase/LobbyPhase.java
+++ b/core/src/main/java/de/leonkoth/blockparty/phase/LobbyPhase.java
@@ -5,7 +5,6 @@ import de.leonkoth.blockparty.arena.Arena;
 import de.leonkoth.blockparty.display.DisplayScoreboard;
 import de.leonkoth.blockparty.player.PlayerInfo;
 import de.leonkoth.blockparty.util.Util;
-import de.pauhull.utils.misc.MinecraftVersion;
 import lombok.Getter;
 import org.bukkit.Bukkit;
 import org.bukkit.Sound;
@@ -15,8 +14,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static de.leonkoth.blockparty.locale.BlockPartyLocale.*;
-import static de.pauhull.utils.misc.MinecraftVersion.v1_13;
-
 /**
  * Created by Leon on 15.03.2018.
  * Project Blockparty2
@@ -42,15 +39,7 @@ public class LobbyPhase implements Runnable {
         this.countdown = arena.getLobbyCountdown();
 
         try {
-            if (MinecraftVersion.CURRENT_VERSION.isGreaterOrEquals(MinecraftVersion.v1_9)) {
-                if (MinecraftVersion.CURRENT_VERSION.isLower(v1_13)) {
-                    sound = Sound.valueOf("BLOCK_NOTE_HARP");
-                } else {
-                    sound = Sound.valueOf("BLOCK_NOTE_BLOCK_HARP");
-                }
-            } else {
-                sound = Sound.valueOf("NOTE_PIANO");
-            }
+            sound = Sound.BLOCK_NOTE_BLOCK_HARP;
         } catch (IllegalArgumentException e) {
             Bukkit.getConsoleSender().sendMessage("§c" + e.getMessage());
         }

--- a/core/src/main/java/de/leonkoth/blockparty/player/PlayerData.java
+++ b/core/src/main/java/de/leonkoth/blockparty/player/PlayerData.java
@@ -79,7 +79,15 @@ public class PlayerData {
                 } else if (field.getType() == float.class) {
                     field.set(playerData, (float) config.getDouble(name));
                 } else if (field.getType() == ItemStack[].class) {
-                    field.set(playerData, ((List<ItemStack>) config.get(name)).toArray(new ItemStack[0]));
+                    List<?> items = config.getList(name);
+                    if (items == null) {
+                        field.set(playerData, new ItemStack[0]);
+                    } else {
+                        field.set(playerData, items.stream()
+                                .filter(ItemStack.class::isInstance)
+                                .map(ItemStack.class::cast)
+                                .toArray(ItemStack[]::new));
+                    }
                 } else {
                     field.set(playerData, config.get(name));
                 }
@@ -154,8 +162,9 @@ public class PlayerData {
 
     public void apply(Player player) {
 
-        if (file != null)
+        if (file != null) {
             file.delete();
+        }
 
         player.setHealth(health);
         player.setFoodLevel(foodLevel);

--- a/core/src/main/java/de/leonkoth/blockparty/util/ItemType.java
+++ b/core/src/main/java/de/leonkoth/blockparty/util/ItemType.java
@@ -50,7 +50,7 @@ public enum ItemType {
         i = new ItemStack(this.type);
         ItemMeta m = i.getItemMeta();
         if (this.lore != null) {
-            ArrayList l = new ArrayList();
+            ArrayList<String> l = new ArrayList<>();
             l.add(this.lore);
             m.setLore(l);
         }
@@ -87,4 +87,3 @@ public enum ItemType {
         return this.name;
     }
 }
-

--- a/core/src/main/resources/plugin.yml
+++ b/core/src/main/resources/plugin.yml
@@ -18,4 +18,4 @@ permissions:
     default: true
     description: Access to the main command.
 
-api-version: 1.13
+api-version: 1.20

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -3,47 +3,40 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>blockparty-parent</artifactId>
         <groupId>de.leonkoth</groupId>
+        <artifactId>blockparty-parent</artifactId>
         <version>2.0.5-RELEASE</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>blockparty-dist</artifactId>
-    <version>${project.parent.version}</version>
-    <packaging>jar</packaging>
 
     <dependencies>
         <dependency>
             <groupId>de.leonkoth</groupId>
             <artifactId>blockparty-core</artifactId>
-            <version>${project.parent.version}</version>
         </dependency>
         <dependency>
             <groupId>de.leonkoth</groupId>
             <artifactId>blockparty-spigot_v1_8_R3</artifactId>
-            <version>${project.parent.version}</version>
         </dependency>
         <dependency>
             <groupId>de.leonkoth</groupId>
             <artifactId>blockparty-spigot_v1_13_R1</artifactId>
-            <version>${project.parent.version}</version>
         </dependency>
         <dependency>
             <groupId>de.leonkoth</groupId>
             <artifactId>blockparty-spigot_v1_14_R1</artifactId>
-            <version>${project.parent.version}</version>
         </dependency>
         <dependency>
             <groupId>de.leonkoth</groupId>
             <artifactId>blockparty-utils</artifactId>
-            <version>${project.parent.version}</version>
         </dependency>
         <dependency>
             <groupId>de.leonkoth</groupId>
             <artifactId>blockparty-api</artifactId>
-            <version>${project.parent.version}</version>
         </dependency>
+        <!-- expansion has its own version independent of parent -->
         <dependency>
             <groupId>de.leonkoth</groupId>
             <artifactId>blockparty-expansion</artifactId>
@@ -59,31 +52,18 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.1</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
-                        <goals>
-                            <goal>shade</goal>
-                        </goals>
+                        <goals><goal>shade</goal></goals>
                         <configuration>
                             <filters>
                                 <filter>
                                     <artifact>*:*</artifact>
-                                    <excludes>
-                                        <exclude>META-INF/**</exclude>
-                                    </excludes>
-                                </filter>
-                                <filter>
-                                    <artifact>de.leonkoth:blockparty-*</artifact>
-                                    <includes>
-                                        <include>**</include>
-                                    </includes>
+                                    <excludes><exclude>META-INF/**</exclude></excludes>
                                 </filter>
                             </filters>
-
                             <minimizeJar>true</minimizeJar>
-
                             <createDependencyReducedPom>false</createDependencyReducedPom>
                         </configuration>
                     </execution>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>de.leonkoth</groupId>
         <artifactId>blockparty-parent</artifactId>
-        <version>2.0.5-RELEASE</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -15,30 +15,6 @@
         <dependency>
             <groupId>de.leonkoth</groupId>
             <artifactId>blockparty-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>de.leonkoth</groupId>
-            <artifactId>blockparty-spigot_v1_8_R3</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>de.leonkoth</groupId>
-            <artifactId>blockparty-spigot_v1_13_R1</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>de.leonkoth</groupId>
-            <artifactId>blockparty-spigot_v1_14_R1</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>de.leonkoth</groupId>
-            <artifactId>blockparty-spigot_v1_16_R3</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>de.leonkoth</groupId>
-            <artifactId>blockparty-spigot_v1_18_R2</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>de.leonkoth</groupId>
-            <artifactId>blockparty-spigot_v1_19_R3</artifactId>
         </dependency>
         <dependency>
             <groupId>de.leonkoth</groupId>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -30,6 +30,26 @@
         </dependency>
         <dependency>
             <groupId>de.leonkoth</groupId>
+            <artifactId>blockparty-spigot_v1_16_R3</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>de.leonkoth</groupId>
+            <artifactId>blockparty-spigot_v1_18_R2</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>de.leonkoth</groupId>
+            <artifactId>blockparty-spigot_v1_19_R3</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>de.leonkoth</groupId>
+            <artifactId>blockparty-spigot_v1_20_R1</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>de.leonkoth</groupId>
+            <artifactId>blockparty-spigot_v1_21_R1</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>de.leonkoth</groupId>
             <artifactId>blockparty-utils</artifactId>
         </dependency>
         <dependency>

--- a/expansion/pom.xml
+++ b/expansion/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>de.leonkoth</groupId>
         <artifactId>blockparty-parent</artifactId>
-        <version>2.0.5-RELEASE</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.15.2-R0.1-SNAPSHOT</version>
+            <version>1.20.6-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/expansion/pom.xml
+++ b/expansion/pom.xml
@@ -16,7 +16,7 @@
     <repositories>
         <repository>
             <id>placeholderapi</id>
-            <url>http://repo.extendedclip.com/content/repositories/placeholderapi/</url>
+            <url>https://repo.extendedclip.com/releases/</url>
         </repository>
         <repository>
             <id>spigot</id>
@@ -34,7 +34,8 @@
         <dependency>
             <groupId>me.clip</groupId>
             <artifactId>placeholderapi</artifactId>
-            <version>2.10.3</version>
+            <version>2.12.2</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.spigotmc</groupId>
@@ -46,14 +47,8 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.0</version>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                    <encoding>UTF-8</encoding>
-                    <forceJavacCompilerUse>true</forceJavacCompilerUse>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/expansion/pom.xml
+++ b/expansion/pom.xml
@@ -3,24 +3,19 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>blockparty-parent</artifactId>
         <groupId>de.leonkoth</groupId>
+        <artifactId>blockparty-parent</artifactId>
         <version>2.0.5-RELEASE</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>blockparty-expansion</artifactId>
     <version>1.0.3</version>
-    <packaging>jar</packaging>
 
     <repositories>
         <repository>
             <id>placeholderapi</id>
             <url>https://repo.extendedclip.com/releases/</url>
-        </repository>
-        <repository>
-            <id>spigot</id>
-            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
         </repository>
     </repositories>
 
@@ -28,29 +23,18 @@
         <dependency>
             <groupId>de.leonkoth</groupId>
             <artifactId>blockparty-core</artifactId>
-            <version>${project.parent.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>me.clip</groupId>
             <artifactId>placeholderapi</artifactId>
-            <version>2.12.2</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
             <version>1.15.2-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-            </plugin>
-        </plugins>
-    </build>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -7,25 +7,152 @@
     <groupId>de.leonkoth</groupId>
     <artifactId>blockparty-parent</artifactId>
     <version>2.0.5-RELEASE</version>
-    <modules>
-        <module>core</module>
-        <module>dist</module>
-        <module>spigot_v1_8_R3</module>
-        <module>spigot_v1_13_R1</module>
-        <module>spigot_v1_14_R1</module>
-        <module>utils</module>
-        <module>api</module>
-        <module>expansion</module>
-    </modules>
     <packaging>pom</packaging>
     <name>BlockParty</name>
 
+    <modules>
+        <module>api</module>
+        <module>utils</module>
+        <module>core</module>
+        <module>spigot_v1_8_R3</module>
+        <module>spigot_v1_13_R1</module>
+        <module>spigot_v1_14_R1</module>
+        <module>expansion</module>
+        <module>dist</module>
+    </modules>
+
     <properties>
         <lombok.version>1.18.38</lombok.version>
+        <spigot.version>1.17-R0.1-SNAPSHOT</spigot.version>
+        <jetty.version>9.4.57.v20241219</jetty.version>
+        <java-websocket.version>1.6.0</java-websocket.version>
+        <bstats.version>3.1.0</bstats.version>
+        <timocloud.version>6.7.9</timocloud.version>
+        <placeholderapi.version>2.12.2</placeholderapi.version>
+        <!-- Explicit property avoids ${project.version} resolving to expansion's 1.0.3 -->
+        <blockparty.version>2.0.5-RELEASE</blockparty.version>
     </properties>
 
+    <repositories>
+        <repository>
+            <id>spigot</id>
+            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
+            <snapshots><enabled>true</enabled></snapshots>
+            <releases><enabled>false</enabled></releases>
+        </repository>
+    </repositories>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- Spigot API (default version; version-specific modules override) -->
+            <dependency>
+                <groupId>org.spigotmc</groupId>
+                <artifactId>spigot-api</artifactId>
+                <version>${spigot.version}</version>
+                <scope>provided</scope>
+            </dependency>
+
+            <!-- Jetty uber JAR -->
+            <dependency>
+                <groupId>org.eclipse.jetty.aggregate</groupId>
+                <artifactId>jetty-all</artifactId>
+                <version>${jetty.version}</version>
+                <classifier>uber</classifier>
+                <scope>compile</scope>
+            </dependency>
+
+            <!-- Java-WebSocket -->
+            <dependency>
+                <groupId>org.java-websocket</groupId>
+                <artifactId>Java-WebSocket</artifactId>
+                <version>${java-websocket.version}</version>
+                <scope>provided</scope>
+            </dependency>
+
+            <!-- bStats -->
+            <dependency>
+                <groupId>org.bstats</groupId>
+                <artifactId>bstats-bukkit</artifactId>
+                <version>${bstats.version}</version>
+                <scope>compile</scope>
+            </dependency>
+
+            <!-- Null-safety annotations -->
+            <dependency>
+                <groupId>com.google.code.findbugs</groupId>
+                <artifactId>jsr305</artifactId>
+                <version>3.0.2</version>
+                <scope>provided</scope>
+            </dependency>
+
+            <!-- TimoCloud -->
+            <dependency>
+                <groupId>cloud.timo.timocloud</groupId>
+                <artifactId>TimoCloud-API</artifactId>
+                <version>${timocloud.version}</version>
+                <scope>provided</scope>
+            </dependency>
+
+            <!-- PlaceholderAPI -->
+            <dependency>
+                <groupId>me.clip</groupId>
+                <artifactId>placeholderapi</artifactId>
+                <version>${placeholderapi.version}</version>
+                <scope>provided</scope>
+            </dependency>
+
+            <!-- MCJukebox -->
+            <dependency>
+                <groupId>com.github.oliverdunk</groupId>
+                <artifactId>JukeboxAPI</artifactId>
+                <version>v2.5.3</version>
+                <scope>provided</scope>
+            </dependency>
+
+            <!-- NoteBlockAPI -->
+            <dependency>
+                <groupId>com.github.koca2000</groupId>
+                <artifactId>NoteBlockAPI</artifactId>
+                <version>1.6.1</version>
+                <scope>provided</scope>
+            </dependency>
+
+            <!-- Internal modules -->
+            <dependency>
+                <groupId>de.leonkoth</groupId>
+                <artifactId>blockparty-api</artifactId>
+                <version>${blockparty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>de.leonkoth</groupId>
+                <artifactId>blockparty-utils</artifactId>
+                <version>${blockparty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>de.leonkoth</groupId>
+                <artifactId>blockparty-core</artifactId>
+                <version>${blockparty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>de.leonkoth</groupId>
+                <artifactId>blockparty-spigot_v1_8_R3</artifactId>
+                <version>${blockparty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>de.leonkoth</groupId>
+                <artifactId>blockparty-spigot_v1_13_R1</artifactId>
+                <version>${blockparty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>de.leonkoth</groupId>
+                <artifactId>blockparty-spigot_v1_14_R1</artifactId>
+                <version>${blockparty.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
-        <!-- Lombok -->
+        <!-- Lombok inherited by all modules -->
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
@@ -52,6 +179,16 @@
                             </path>
                         </annotationProcessorPaths>
                     </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-shade-plugin</artifactId>
+                    <version>3.6.2</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>3.5.0</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -20,14 +20,41 @@
     <packaging>pom</packaging>
     <name>BlockParty</name>
 
+    <properties>
+        <lombok.version>1.18.38</lombok.version>
+    </properties>
+
     <dependencies>
         <!-- Lombok -->
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.12</version>
+            <version>${lombok.version}</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.13.0</version>
+                    <configuration>
+                        <release>8</release>
+                        <encoding>UTF-8</encoding>
+                        <annotationProcessorPaths>
+                            <path>
+                                <groupId>org.projectlombok</groupId>
+                                <artifactId>lombok</artifactId>
+                                <version>${lombok.version}</version>
+                            </path>
+                        </annotationProcessorPaths>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>de.leonkoth</groupId>
     <artifactId>blockparty-parent</artifactId>
-    <version>2.0.5-RELEASE</version>
+    <version>3.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>BlockParty</name>
 
@@ -14,12 +14,6 @@
         <module>api</module>
         <module>utils</module>
         <module>core</module>
-        <module>spigot_v1_8_R3</module>
-        <module>spigot_v1_13_R1</module>
-        <module>spigot_v1_14_R1</module>
-        <module>spigot_v1_16_R3</module>
-        <module>spigot_v1_18_R2</module>
-        <module>spigot_v1_19_R3</module>
         <module>spigot_v1_20_R1</module>
         <module>spigot_v1_21_R1</module>
         <module>expansion</module>
@@ -28,14 +22,14 @@
 
     <properties>
         <lombok.version>1.18.38</lombok.version>
-        <spigot.version>1.17-R0.1-SNAPSHOT</spigot.version>
+        <spigot.version>1.20.6-R0.1-SNAPSHOT</spigot.version>
         <jetty.version>9.4.57.v20241219</jetty.version>
         <java-websocket.version>1.6.0</java-websocket.version>
         <bstats.version>3.1.0</bstats.version>
         <timocloud.version>6.7.9</timocloud.version>
         <placeholderapi.version>2.12.2</placeholderapi.version>
         <!-- Explicit property avoids ${project.version} resolving to expansion's 1.0.3 -->
-        <blockparty.version>2.0.5-RELEASE</blockparty.version>
+        <blockparty.version>3.0.0-SNAPSHOT</blockparty.version>
     </properties>
 
     <repositories>
@@ -140,36 +134,6 @@
             </dependency>
             <dependency>
                 <groupId>de.leonkoth</groupId>
-                <artifactId>blockparty-spigot_v1_8_R3</artifactId>
-                <version>${blockparty.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>de.leonkoth</groupId>
-                <artifactId>blockparty-spigot_v1_13_R1</artifactId>
-                <version>${blockparty.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>de.leonkoth</groupId>
-                <artifactId>blockparty-spigot_v1_14_R1</artifactId>
-                <version>${blockparty.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>de.leonkoth</groupId>
-                <artifactId>blockparty-spigot_v1_16_R3</artifactId>
-                <version>${blockparty.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>de.leonkoth</groupId>
-                <artifactId>blockparty-spigot_v1_18_R2</artifactId>
-                <version>${blockparty.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>de.leonkoth</groupId>
-                <artifactId>blockparty-spigot_v1_19_R3</artifactId>
-                <version>${blockparty.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>de.leonkoth</groupId>
                 <artifactId>blockparty-spigot_v1_20_R1</artifactId>
                 <version>${blockparty.version}</version>
             </dependency>
@@ -199,7 +163,7 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.13.0</version>
                     <configuration>
-                        <release>8</release>
+                        <release>21</release>
                         <encoding>UTF-8</encoding>
                         <annotationProcessorPaths>
                             <path>

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,11 @@
         <module>spigot_v1_8_R3</module>
         <module>spigot_v1_13_R1</module>
         <module>spigot_v1_14_R1</module>
+        <module>spigot_v1_16_R3</module>
+        <module>spigot_v1_18_R2</module>
+        <module>spigot_v1_19_R3</module>
+        <module>spigot_v1_20_R1</module>
+        <module>spigot_v1_21_R1</module>
         <module>expansion</module>
         <module>dist</module>
     </modules>
@@ -146,6 +151,31 @@
             <dependency>
                 <groupId>de.leonkoth</groupId>
                 <artifactId>blockparty-spigot_v1_14_R1</artifactId>
+                <version>${blockparty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>de.leonkoth</groupId>
+                <artifactId>blockparty-spigot_v1_16_R3</artifactId>
+                <version>${blockparty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>de.leonkoth</groupId>
+                <artifactId>blockparty-spigot_v1_18_R2</artifactId>
+                <version>${blockparty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>de.leonkoth</groupId>
+                <artifactId>blockparty-spigot_v1_19_R3</artifactId>
+                <version>${blockparty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>de.leonkoth</groupId>
+                <artifactId>blockparty-spigot_v1_20_R1</artifactId>
+                <version>${blockparty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>de.leonkoth</groupId>
+                <artifactId>blockparty-spigot_v1_21_R1</artifactId>
                 <version>${blockparty.version}</version>
             </dependency>
         </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,8 @@
     </modules>
 
     <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <lombok.version>1.18.38</lombok.version>
         <spigot.version>1.20.6-R0.1-SNAPSHOT</spigot.version>
         <jetty.version>9.4.57.v20241219</jetty.version>

--- a/spigot_v1_13_R1/pom.xml
+++ b/spigot_v1_13_R1/pom.xml
@@ -14,13 +14,8 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.7.0</version>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                    <encoding>UTF-8</encoding>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/spigot_v1_13_R1/pom.xml
+++ b/spigot_v1_13_R1/pom.xml
@@ -3,55 +3,31 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>blockparty-parent</artifactId>
         <groupId>de.leonkoth</groupId>
+        <artifactId>blockparty-parent</artifactId>
         <version>2.0.5-RELEASE</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>blockparty-spigot_v1_13_R1</artifactId>
-    <version>${project.parent.version}</version>
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-            </plugin>
-        </plugins>
-    </build>
-    <packaging>jar</packaging>
-
-    <repositories>
-        <repository>
-            <id>spigot</id>
-            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
-        </repository>
-
-    </repositories>
 
     <dependencies>
-
-        <!--Spigot API-->
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
             <version>1.13-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
-
         <dependency>
             <groupId>de.leonkoth</groupId>
             <artifactId>blockparty-core</artifactId>
-            <version>${project.parent.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>de.leonkoth</groupId>
             <artifactId>blockparty-api</artifactId>
-            <version>${project.parent.version}</version>
-            <scope>compile</scope>
+            <scope>provided</scope>
         </dependency>
-
     </dependencies>
 
 </project>

--- a/spigot_v1_14_R1/pom.xml
+++ b/spigot_v1_14_R1/pom.xml
@@ -14,13 +14,8 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.7.0</version>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                    <encoding>UTF-8</encoding>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/spigot_v1_14_R1/pom.xml
+++ b/spigot_v1_14_R1/pom.xml
@@ -3,55 +3,31 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>blockparty-parent</artifactId>
         <groupId>de.leonkoth</groupId>
+        <artifactId>blockparty-parent</artifactId>
         <version>2.0.5-RELEASE</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>blockparty-spigot_v1_14_R1</artifactId>
-    <version>${project.parent.version}</version>
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-            </plugin>
-        </plugins>
-    </build>
-    <packaging>jar</packaging>
-
-    <repositories>
-        <repository>
-            <id>spigot</id>
-            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
-        </repository>
-
-    </repositories>
 
     <dependencies>
-
-        <!--Spigot API-->
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
             <version>1.14.3-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
-
         <dependency>
             <groupId>de.leonkoth</groupId>
             <artifactId>blockparty-core</artifactId>
-            <version>${project.parent.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>de.leonkoth</groupId>
             <artifactId>blockparty-api</artifactId>
-            <version>${project.parent.version}</version>
-            <scope>compile</scope>
+            <scope>provided</scope>
         </dependency>
-
     </dependencies>
 
 </project>

--- a/spigot_v1_16_R3/pom.xml
+++ b/spigot_v1_16_R3/pom.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>de.leonkoth</groupId>
+        <artifactId>blockparty-parent</artifactId>
+        <version>2.0.5-RELEASE</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>blockparty-spigot_v1_16_R3</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot-api</artifactId>
+            <version>1.16.5-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>de.leonkoth</groupId>
+            <artifactId>blockparty-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/spigot_v1_16_R3/src/main/java/de/leonkoth/blockparty/version/v1_16_R3/materials/MusicDisc.java
+++ b/spigot_v1_16_R3/src/main/java/de/leonkoth/blockparty/version/v1_16_R3/materials/MusicDisc.java
@@ -1,0 +1,30 @@
+package de.leonkoth.blockparty.version.v1_16_R3.materials;
+
+import de.leonkoth.blockparty.version.BlockPartyMaterial;
+import org.bukkit.Material;
+
+public class MusicDisc extends BlockPartyMaterial {
+
+    public MusicDisc() {
+        super();
+        this.materials.add(Material.MUSIC_DISC_BLOCKS);
+        this.materials.add(Material.MUSIC_DISC_11);
+        this.materials.add(Material.MUSIC_DISC_13);
+        this.materials.add(Material.MUSIC_DISC_CAT);
+        this.materials.add(Material.MUSIC_DISC_CHIRP);
+        this.materials.add(Material.MUSIC_DISC_FAR);
+        this.materials.add(Material.MUSIC_DISC_MALL);
+        this.materials.add(Material.MUSIC_DISC_MELLOHI);
+        this.materials.add(Material.MUSIC_DISC_STAL);
+        this.materials.add(Material.MUSIC_DISC_STRAD);
+        this.materials.add(Material.MUSIC_DISC_WAIT);
+        this.materials.add(Material.MUSIC_DISC_WARD);
+        this.materials.add(Material.MUSIC_DISC_PIGSTEP);
+    }
+
+    @Override
+    protected String getSuffix() {
+        return null;
+    }
+
+}

--- a/spigot_v1_18_R2/pom.xml
+++ b/spigot_v1_18_R2/pom.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>de.leonkoth</groupId>
+        <artifactId>blockparty-parent</artifactId>
+        <version>2.0.5-RELEASE</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>blockparty-spigot_v1_18_R2</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot-api</artifactId>
+            <version>1.18.2-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>de.leonkoth</groupId>
+            <artifactId>blockparty-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/spigot_v1_18_R2/src/main/java/de/leonkoth/blockparty/version/v1_18_R2/materials/MusicDisc.java
+++ b/spigot_v1_18_R2/src/main/java/de/leonkoth/blockparty/version/v1_18_R2/materials/MusicDisc.java
@@ -1,0 +1,31 @@
+package de.leonkoth.blockparty.version.v1_18_R2.materials;
+
+import de.leonkoth.blockparty.version.BlockPartyMaterial;
+import org.bukkit.Material;
+
+public class MusicDisc extends BlockPartyMaterial {
+
+    public MusicDisc() {
+        super();
+        this.materials.add(Material.MUSIC_DISC_BLOCKS);
+        this.materials.add(Material.MUSIC_DISC_11);
+        this.materials.add(Material.MUSIC_DISC_13);
+        this.materials.add(Material.MUSIC_DISC_CAT);
+        this.materials.add(Material.MUSIC_DISC_CHIRP);
+        this.materials.add(Material.MUSIC_DISC_FAR);
+        this.materials.add(Material.MUSIC_DISC_MALL);
+        this.materials.add(Material.MUSIC_DISC_MELLOHI);
+        this.materials.add(Material.MUSIC_DISC_STAL);
+        this.materials.add(Material.MUSIC_DISC_STRAD);
+        this.materials.add(Material.MUSIC_DISC_WAIT);
+        this.materials.add(Material.MUSIC_DISC_WARD);
+        this.materials.add(Material.MUSIC_DISC_PIGSTEP);
+        this.materials.add(Material.MUSIC_DISC_OTHERSIDE);
+    }
+
+    @Override
+    protected String getSuffix() {
+        return null;
+    }
+
+}

--- a/spigot_v1_19_R3/pom.xml
+++ b/spigot_v1_19_R3/pom.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>de.leonkoth</groupId>
+        <artifactId>blockparty-parent</artifactId>
+        <version>2.0.5-RELEASE</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>blockparty-spigot_v1_19_R3</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot-api</artifactId>
+            <version>1.19.4-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>de.leonkoth</groupId>
+            <artifactId>blockparty-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/spigot_v1_19_R3/src/main/java/de/leonkoth/blockparty/version/v1_19_R3/materials/MusicDisc.java
+++ b/spigot_v1_19_R3/src/main/java/de/leonkoth/blockparty/version/v1_19_R3/materials/MusicDisc.java
@@ -1,0 +1,32 @@
+package de.leonkoth.blockparty.version.v1_19_R3.materials;
+
+import de.leonkoth.blockparty.version.BlockPartyMaterial;
+import org.bukkit.Material;
+
+public class MusicDisc extends BlockPartyMaterial {
+
+    public MusicDisc() {
+        super();
+        this.materials.add(Material.MUSIC_DISC_BLOCKS);
+        this.materials.add(Material.MUSIC_DISC_11);
+        this.materials.add(Material.MUSIC_DISC_13);
+        this.materials.add(Material.MUSIC_DISC_CAT);
+        this.materials.add(Material.MUSIC_DISC_CHIRP);
+        this.materials.add(Material.MUSIC_DISC_FAR);
+        this.materials.add(Material.MUSIC_DISC_MALL);
+        this.materials.add(Material.MUSIC_DISC_MELLOHI);
+        this.materials.add(Material.MUSIC_DISC_STAL);
+        this.materials.add(Material.MUSIC_DISC_STRAD);
+        this.materials.add(Material.MUSIC_DISC_WAIT);
+        this.materials.add(Material.MUSIC_DISC_WARD);
+        this.materials.add(Material.MUSIC_DISC_PIGSTEP);
+        this.materials.add(Material.MUSIC_DISC_OTHERSIDE);
+        this.materials.add(Material.MUSIC_DISC_5);
+    }
+
+    @Override
+    protected String getSuffix() {
+        return null;
+    }
+
+}

--- a/spigot_v1_20_R1/pom.xml
+++ b/spigot_v1_20_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>de.leonkoth</groupId>
         <artifactId>blockparty-parent</artifactId>
-        <version>2.0.5-RELEASE</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.20.4-R0.1-SNAPSHOT</version>
+            <version>1.20.6-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/spigot_v1_20_R1/pom.xml
+++ b/spigot_v1_20_R1/pom.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>de.leonkoth</groupId>
+        <artifactId>blockparty-parent</artifactId>
+        <version>2.0.5-RELEASE</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>blockparty-spigot_v1_20_R1</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot-api</artifactId>
+            <version>1.20.4-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>de.leonkoth</groupId>
+            <artifactId>blockparty-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/spigot_v1_20_R1/src/main/java/de/leonkoth/blockparty/version/v1_20_R1/BlockPlacer.java
+++ b/spigot_v1_20_R1/src/main/java/de/leonkoth/blockparty/version/v1_20_R1/BlockPlacer.java
@@ -1,0 +1,93 @@
+package de.leonkoth.blockparty.version.v1_20_R1;
+
+import de.leonkoth.blockparty.version.BlockInfo;
+import de.leonkoth.blockparty.version.BlockPartyMaterial;
+import de.leonkoth.blockparty.version.IBlockPlacer;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class BlockPlacer implements IBlockPlacer {
+
+    private final Map<Byte, String> dataAndMaterialColorPrefix;
+
+    public BlockPlacer() {
+        dataAndMaterialColorPrefix = new HashMap<>();
+        dataAndMaterialColorPrefix.put((byte) 0, "WHITE");
+        dataAndMaterialColorPrefix.put((byte) 1, "ORANGE");
+        dataAndMaterialColorPrefix.put((byte) 2, "MAGENTA");
+        dataAndMaterialColorPrefix.put((byte) 3, "LIGHT_BLUE");
+        dataAndMaterialColorPrefix.put((byte) 4, "YELLOW");
+        dataAndMaterialColorPrefix.put((byte) 5, "LIME");
+        dataAndMaterialColorPrefix.put((byte) 6, "PINK");
+        dataAndMaterialColorPrefix.put((byte) 7, "GRAY");
+        dataAndMaterialColorPrefix.put((byte) 8, "LIGHT_GRAY");
+        dataAndMaterialColorPrefix.put((byte) 9, "CYAN");
+        dataAndMaterialColorPrefix.put((byte) 10, "PURPLE");
+        dataAndMaterialColorPrefix.put((byte) 11, "BLUE");
+        dataAndMaterialColorPrefix.put((byte) 12, "BROWN");
+        dataAndMaterialColorPrefix.put((byte) 13, "GREEN");
+        dataAndMaterialColorPrefix.put((byte) 14, "RED");
+        dataAndMaterialColorPrefix.put((byte) 15, "BLACK");
+    }
+
+    @Override
+    public void place(World world, int x, int y, int z, BlockPartyMaterial material, byte data) {
+        world.getBlockAt(x, y, z).setType(material.get(data));
+    }
+
+    @Override
+    public void place(World world, int x, int y, int z, Material material, byte data) {
+        world.getBlockAt(x, y, z).setType(material);
+    }
+
+    @Override
+    public void place(Location location, BlockPartyMaterial material, byte data) {
+        location.getBlock().setType(material.get(data));
+    }
+
+    @Override
+    public void place(Location location, Material material, byte data) {
+        location.getBlock().setType(material);
+    }
+
+    @Override
+    public void place(Block block, BlockPartyMaterial material, byte data) {
+        block.setType(material.get(data));
+    }
+
+    @Override
+    public void place(Block block, Material material, byte data) {
+        block.setType(material);
+    }
+
+    @Override
+    public BlockInfo getBlockInfo(Location loc, Block block) {
+        return new BlockInfo(loc, block.getType(), (byte) 0);
+    }
+
+    @Override
+    public Byte getData(World world, int x, int y, int z) {
+        return getDataByMaterial(world.getBlockAt(x, y, z).getType());
+    }
+
+    private byte getDataByMaterial(Material material) {
+        String materialName = material.name();
+        int last = materialName.indexOf('_');
+
+        if (last > -1) {
+            String prefix = materialName.substring(0, last);
+            for (Map.Entry<Byte, String> entry : dataAndMaterialColorPrefix.entrySet()) {
+                if (entry.getValue().equals(prefix)) {
+                    return entry.getKey();
+                }
+            }
+        }
+
+        return 0;
+    }
+}

--- a/spigot_v1_20_R1/src/main/java/de/leonkoth/blockparty/version/v1_20_R1/materials/Carpet.java
+++ b/spigot_v1_20_R1/src/main/java/de/leonkoth/blockparty/version/v1_20_R1/materials/Carpet.java
@@ -1,0 +1,32 @@
+package de.leonkoth.blockparty.version.v1_20_R1.materials;
+
+import de.leonkoth.blockparty.version.BlockPartyMaterial;
+import org.bukkit.Material;
+
+public class Carpet extends BlockPartyMaterial {
+
+    public Carpet() {
+        super();
+        this.materials.add(Material.WHITE_CARPET);
+        this.materials.add(Material.ORANGE_CARPET);
+        this.materials.add(Material.MAGENTA_CARPET);
+        this.materials.add(Material.LIGHT_BLUE_CARPET);
+        this.materials.add(Material.YELLOW_CARPET);
+        this.materials.add(Material.LIME_CARPET);
+        this.materials.add(Material.PINK_CARPET);
+        this.materials.add(Material.GRAY_CARPET);
+        this.materials.add(Material.LIGHT_GRAY_CARPET);
+        this.materials.add(Material.CYAN_CARPET);
+        this.materials.add(Material.PURPLE_CARPET);
+        this.materials.add(Material.BLUE_CARPET);
+        this.materials.add(Material.BROWN_CARPET);
+        this.materials.add(Material.GREEN_CARPET);
+        this.materials.add(Material.RED_CARPET);
+        this.materials.add(Material.BLACK_CARPET);
+    }
+
+    @Override
+    protected String getSuffix() {
+        return "_CARPET";
+    }
+}

--- a/spigot_v1_20_R1/src/main/java/de/leonkoth/blockparty/version/v1_20_R1/materials/Door.java
+++ b/spigot_v1_20_R1/src/main/java/de/leonkoth/blockparty/version/v1_20_R1/materials/Door.java
@@ -1,0 +1,30 @@
+package de.leonkoth.blockparty.version.v1_20_R1.materials;
+
+import de.leonkoth.blockparty.version.BlockPartyMaterial;
+import org.bukkit.Material;
+
+public class Door extends BlockPartyMaterial {
+
+    private final Material door;
+
+    public Door() {
+        super();
+        this.door = Material.ACACIA_DOOR;
+        this.materials.add(door);
+    }
+
+    @Override
+    protected String getSuffix() {
+        return null;
+    }
+
+    @Override
+    public boolean equals(Material material) {
+        return material == this.door;
+    }
+
+    @Override
+    public Material get(int t) {
+        return this.door;
+    }
+}

--- a/spigot_v1_20_R1/src/main/java/de/leonkoth/blockparty/version/v1_20_R1/materials/FireCharge.java
+++ b/spigot_v1_20_R1/src/main/java/de/leonkoth/blockparty/version/v1_20_R1/materials/FireCharge.java
@@ -1,0 +1,30 @@
+package de.leonkoth.blockparty.version.v1_20_R1.materials;
+
+import de.leonkoth.blockparty.version.BlockPartyMaterial;
+import org.bukkit.Material;
+
+public class FireCharge extends BlockPartyMaterial {
+
+    private final Material fireCharge;
+
+    public FireCharge() {
+        super();
+        this.fireCharge = Material.FIRE_CHARGE;
+        this.materials.add(fireCharge);
+    }
+
+    @Override
+    protected String getSuffix() {
+        return null;
+    }
+
+    @Override
+    public boolean equals(Material material) {
+        return material == this.fireCharge;
+    }
+
+    @Override
+    public Material get(int t) {
+        return this.fireCharge;
+    }
+}

--- a/spigot_v1_20_R1/src/main/java/de/leonkoth/blockparty/version/v1_20_R1/materials/MusicDisc.java
+++ b/spigot_v1_20_R1/src/main/java/de/leonkoth/blockparty/version/v1_20_R1/materials/MusicDisc.java
@@ -1,0 +1,33 @@
+package de.leonkoth.blockparty.version.v1_20_R1.materials;
+
+import de.leonkoth.blockparty.version.BlockPartyMaterial;
+import org.bukkit.Material;
+
+public class MusicDisc extends BlockPartyMaterial {
+
+    public MusicDisc() {
+        super();
+        this.materials.add(Material.MUSIC_DISC_BLOCKS);
+        this.materials.add(Material.MUSIC_DISC_11);
+        this.materials.add(Material.MUSIC_DISC_13);
+        this.materials.add(Material.MUSIC_DISC_CAT);
+        this.materials.add(Material.MUSIC_DISC_CHIRP);
+        this.materials.add(Material.MUSIC_DISC_FAR);
+        this.materials.add(Material.MUSIC_DISC_MALL);
+        this.materials.add(Material.MUSIC_DISC_MELLOHI);
+        this.materials.add(Material.MUSIC_DISC_STAL);
+        this.materials.add(Material.MUSIC_DISC_STRAD);
+        this.materials.add(Material.MUSIC_DISC_WAIT);
+        this.materials.add(Material.MUSIC_DISC_WARD);
+        this.materials.add(Material.MUSIC_DISC_PIGSTEP);
+        this.materials.add(Material.MUSIC_DISC_OTHERSIDE);
+        this.materials.add(Material.MUSIC_DISC_5);
+        this.materials.add(Material.MUSIC_DISC_RELIC);
+    }
+
+    @Override
+    protected String getSuffix() {
+        return null;
+    }
+
+}

--- a/spigot_v1_20_R1/src/main/java/de/leonkoth/blockparty/version/v1_20_R1/materials/Sign.java
+++ b/spigot_v1_20_R1/src/main/java/de/leonkoth/blockparty/version/v1_20_R1/materials/Sign.java
@@ -1,0 +1,45 @@
+package de.leonkoth.blockparty.version.v1_20_R1.materials;
+
+import de.leonkoth.blockparty.version.BlockPartyMaterial;
+import org.bukkit.Material;
+
+import java.util.List;
+
+public class Sign extends BlockPartyMaterial {
+
+    public Sign() {
+        super(signMaterials());
+    }
+
+    @Override
+    protected String getSuffix() {
+        return null;
+    }
+
+    private static List<Material> signMaterials() {
+        return List.of(
+                Material.OAK_SIGN,
+                Material.OAK_WALL_SIGN,
+                Material.SPRUCE_SIGN,
+                Material.SPRUCE_WALL_SIGN,
+                Material.BIRCH_SIGN,
+                Material.BIRCH_WALL_SIGN,
+                Material.JUNGLE_SIGN,
+                Material.JUNGLE_WALL_SIGN,
+                Material.ACACIA_SIGN,
+                Material.ACACIA_WALL_SIGN,
+                Material.DARK_OAK_SIGN,
+                Material.DARK_OAK_WALL_SIGN,
+                Material.MANGROVE_SIGN,
+                Material.MANGROVE_WALL_SIGN,
+                Material.CHERRY_SIGN,
+                Material.CHERRY_WALL_SIGN,
+                Material.BAMBOO_SIGN,
+                Material.BAMBOO_WALL_SIGN,
+                Material.CRIMSON_SIGN,
+                Material.CRIMSON_WALL_SIGN,
+                Material.WARPED_SIGN,
+                Material.WARPED_WALL_SIGN
+        );
+    }
+}

--- a/spigot_v1_20_R1/src/main/java/de/leonkoth/blockparty/version/v1_20_R1/materials/SkeletonSkull.java
+++ b/spigot_v1_20_R1/src/main/java/de/leonkoth/blockparty/version/v1_20_R1/materials/SkeletonSkull.java
@@ -1,0 +1,30 @@
+package de.leonkoth.blockparty.version.v1_20_R1.materials;
+
+import de.leonkoth.blockparty.version.BlockPartyMaterial;
+import org.bukkit.Material;
+
+public class SkeletonSkull extends BlockPartyMaterial {
+
+    private final Material skeletonSkull;
+
+    public SkeletonSkull() {
+        super();
+        this.skeletonSkull = Material.SKELETON_SKULL;
+        this.materials.add(skeletonSkull);
+    }
+
+    @Override
+    protected String getSuffix() {
+        return null;
+    }
+
+    @Override
+    public boolean equals(Material material) {
+        return material == this.skeletonSkull;
+    }
+
+    @Override
+    public Material get(int t) {
+        return this.skeletonSkull;
+    }
+}

--- a/spigot_v1_20_R1/src/main/java/de/leonkoth/blockparty/version/v1_20_R1/materials/StainedGlass.java
+++ b/spigot_v1_20_R1/src/main/java/de/leonkoth/blockparty/version/v1_20_R1/materials/StainedGlass.java
@@ -1,0 +1,32 @@
+package de.leonkoth.blockparty.version.v1_20_R1.materials;
+
+import de.leonkoth.blockparty.version.BlockPartyMaterial;
+import org.bukkit.Material;
+
+public class StainedGlass extends BlockPartyMaterial {
+
+    public StainedGlass() {
+        super();
+        this.materials.add(Material.WHITE_STAINED_GLASS);
+        this.materials.add(Material.ORANGE_STAINED_GLASS);
+        this.materials.add(Material.MAGENTA_STAINED_GLASS);
+        this.materials.add(Material.LIGHT_BLUE_STAINED_GLASS);
+        this.materials.add(Material.YELLOW_STAINED_GLASS);
+        this.materials.add(Material.LIME_STAINED_GLASS);
+        this.materials.add(Material.PINK_STAINED_GLASS);
+        this.materials.add(Material.GRAY_STAINED_GLASS);
+        this.materials.add(Material.LIGHT_GRAY_STAINED_GLASS);
+        this.materials.add(Material.CYAN_STAINED_GLASS);
+        this.materials.add(Material.PURPLE_STAINED_GLASS);
+        this.materials.add(Material.BLUE_STAINED_GLASS);
+        this.materials.add(Material.BROWN_STAINED_GLASS);
+        this.materials.add(Material.GREEN_STAINED_GLASS);
+        this.materials.add(Material.RED_STAINED_GLASS);
+        this.materials.add(Material.BLACK_STAINED_GLASS);
+    }
+
+    @Override
+    protected String getSuffix() {
+        return "_STAINED_GLASS";
+    }
+}

--- a/spigot_v1_20_R1/src/main/java/de/leonkoth/blockparty/version/v1_20_R1/materials/StainedGlassPane.java
+++ b/spigot_v1_20_R1/src/main/java/de/leonkoth/blockparty/version/v1_20_R1/materials/StainedGlassPane.java
@@ -1,0 +1,32 @@
+package de.leonkoth.blockparty.version.v1_20_R1.materials;
+
+import de.leonkoth.blockparty.version.BlockPartyMaterial;
+import org.bukkit.Material;
+
+public class StainedGlassPane extends BlockPartyMaterial {
+
+    public StainedGlassPane() {
+        super();
+        this.materials.add(Material.WHITE_STAINED_GLASS_PANE);
+        this.materials.add(Material.ORANGE_STAINED_GLASS_PANE);
+        this.materials.add(Material.MAGENTA_STAINED_GLASS_PANE);
+        this.materials.add(Material.LIGHT_BLUE_STAINED_GLASS_PANE);
+        this.materials.add(Material.YELLOW_STAINED_GLASS_PANE);
+        this.materials.add(Material.LIME_STAINED_GLASS_PANE);
+        this.materials.add(Material.PINK_STAINED_GLASS_PANE);
+        this.materials.add(Material.GRAY_STAINED_GLASS_PANE);
+        this.materials.add(Material.LIGHT_GRAY_STAINED_GLASS_PANE);
+        this.materials.add(Material.CYAN_STAINED_GLASS_PANE);
+        this.materials.add(Material.PURPLE_STAINED_GLASS_PANE);
+        this.materials.add(Material.BLUE_STAINED_GLASS_PANE);
+        this.materials.add(Material.BROWN_STAINED_GLASS_PANE);
+        this.materials.add(Material.GREEN_STAINED_GLASS_PANE);
+        this.materials.add(Material.RED_STAINED_GLASS_PANE);
+        this.materials.add(Material.BLACK_STAINED_GLASS_PANE);
+    }
+
+    @Override
+    protected String getSuffix() {
+        return "_STAINED_GLASS_PANE";
+    }
+}

--- a/spigot_v1_20_R1/src/main/java/de/leonkoth/blockparty/version/v1_20_R1/materials/Terracotta.java
+++ b/spigot_v1_20_R1/src/main/java/de/leonkoth/blockparty/version/v1_20_R1/materials/Terracotta.java
@@ -1,0 +1,32 @@
+package de.leonkoth.blockparty.version.v1_20_R1.materials;
+
+import de.leonkoth.blockparty.version.BlockPartyMaterial;
+import org.bukkit.Material;
+
+public class Terracotta extends BlockPartyMaterial {
+
+    public Terracotta() {
+        super();
+        this.materials.add(Material.WHITE_TERRACOTTA);
+        this.materials.add(Material.ORANGE_TERRACOTTA);
+        this.materials.add(Material.MAGENTA_TERRACOTTA);
+        this.materials.add(Material.LIGHT_BLUE_TERRACOTTA);
+        this.materials.add(Material.YELLOW_TERRACOTTA);
+        this.materials.add(Material.LIME_TERRACOTTA);
+        this.materials.add(Material.PINK_TERRACOTTA);
+        this.materials.add(Material.GRAY_TERRACOTTA);
+        this.materials.add(Material.LIGHT_GRAY_TERRACOTTA);
+        this.materials.add(Material.CYAN_TERRACOTTA);
+        this.materials.add(Material.PURPLE_TERRACOTTA);
+        this.materials.add(Material.BLUE_TERRACOTTA);
+        this.materials.add(Material.BROWN_TERRACOTTA);
+        this.materials.add(Material.GREEN_TERRACOTTA);
+        this.materials.add(Material.RED_TERRACOTTA);
+        this.materials.add(Material.BLACK_TERRACOTTA);
+    }
+
+    @Override
+    protected String getSuffix() {
+        return "_TERRACOTTA";
+    }
+}

--- a/spigot_v1_20_R1/src/main/java/de/leonkoth/blockparty/version/v1_20_R1/materials/Wool.java
+++ b/spigot_v1_20_R1/src/main/java/de/leonkoth/blockparty/version/v1_20_R1/materials/Wool.java
@@ -1,0 +1,32 @@
+package de.leonkoth.blockparty.version.v1_20_R1.materials;
+
+import de.leonkoth.blockparty.version.BlockPartyMaterial;
+import org.bukkit.Material;
+
+public class Wool extends BlockPartyMaterial {
+
+    public Wool() {
+        super();
+        this.materials.add(Material.WHITE_WOOL);
+        this.materials.add(Material.ORANGE_WOOL);
+        this.materials.add(Material.MAGENTA_WOOL);
+        this.materials.add(Material.LIGHT_BLUE_WOOL);
+        this.materials.add(Material.YELLOW_WOOL);
+        this.materials.add(Material.LIME_WOOL);
+        this.materials.add(Material.PINK_WOOL);
+        this.materials.add(Material.GRAY_WOOL);
+        this.materials.add(Material.LIGHT_GRAY_WOOL);
+        this.materials.add(Material.CYAN_WOOL);
+        this.materials.add(Material.PURPLE_WOOL);
+        this.materials.add(Material.BLUE_WOOL);
+        this.materials.add(Material.BROWN_WOOL);
+        this.materials.add(Material.GREEN_WOOL);
+        this.materials.add(Material.RED_WOOL);
+        this.materials.add(Material.BLACK_WOOL);
+    }
+
+    @Override
+    protected String getSuffix() {
+        return "_WOOL";
+    }
+}

--- a/spigot_v1_21_R1/pom.xml
+++ b/spigot_v1_21_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>de.leonkoth</groupId>
         <artifactId>blockparty-parent</artifactId>
-        <version>2.0.5-RELEASE</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/spigot_v1_21_R1/pom.xml
+++ b/spigot_v1_21_R1/pom.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>de.leonkoth</groupId>
+        <artifactId>blockparty-parent</artifactId>
+        <version>2.0.5-RELEASE</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>blockparty-spigot_v1_21_R1</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot-api</artifactId>
+            <version>1.21.1-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>de.leonkoth</groupId>
+            <artifactId>blockparty-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/spigot_v1_21_R1/src/main/java/de/leonkoth/blockparty/version/v1_21_R1/materials/MusicDisc.java
+++ b/spigot_v1_21_R1/src/main/java/de/leonkoth/blockparty/version/v1_21_R1/materials/MusicDisc.java
@@ -1,0 +1,36 @@
+package de.leonkoth.blockparty.version.v1_21_R1.materials;
+
+import de.leonkoth.blockparty.version.BlockPartyMaterial;
+import org.bukkit.Material;
+
+public class MusicDisc extends BlockPartyMaterial {
+
+    public MusicDisc() {
+        super();
+        this.materials.add(Material.MUSIC_DISC_BLOCKS);
+        this.materials.add(Material.MUSIC_DISC_11);
+        this.materials.add(Material.MUSIC_DISC_13);
+        this.materials.add(Material.MUSIC_DISC_CAT);
+        this.materials.add(Material.MUSIC_DISC_CHIRP);
+        this.materials.add(Material.MUSIC_DISC_FAR);
+        this.materials.add(Material.MUSIC_DISC_MALL);
+        this.materials.add(Material.MUSIC_DISC_MELLOHI);
+        this.materials.add(Material.MUSIC_DISC_STAL);
+        this.materials.add(Material.MUSIC_DISC_STRAD);
+        this.materials.add(Material.MUSIC_DISC_WAIT);
+        this.materials.add(Material.MUSIC_DISC_WARD);
+        this.materials.add(Material.MUSIC_DISC_PIGSTEP);
+        this.materials.add(Material.MUSIC_DISC_OTHERSIDE);
+        this.materials.add(Material.MUSIC_DISC_5);
+        this.materials.add(Material.MUSIC_DISC_RELIC);
+        this.materials.add(Material.MUSIC_DISC_CREATOR);
+        this.materials.add(Material.MUSIC_DISC_CREATOR_MUSIC_BOX);
+        this.materials.add(Material.MUSIC_DISC_PRECIPICE);
+    }
+
+    @Override
+    protected String getSuffix() {
+        return null;
+    }
+
+}

--- a/spigot_v1_8_R3/pom.xml
+++ b/spigot_v1_8_R3/pom.xml
@@ -3,55 +3,34 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>blockparty-parent</artifactId>
         <groupId>de.leonkoth</groupId>
+        <artifactId>blockparty-parent</artifactId>
         <version>2.0.5-RELEASE</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>blockparty-spigot_v1_8_R3</artifactId>
-    <version>${project.parent.version}</version>
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-            </plugin>
-        </plugins>
-    </build>
-    <packaging>jar</packaging>
-
-    <repositories>
-        <repository>
-            <id>spigot</id>
-            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
-        </repository>
-
-    </repositories>
 
     <dependencies>
-
-        <!--Spigot API-->
+        <!-- Must stay at 1.8.8 — uses old Material enum constants (WOOL, STAINED_GLASS, etc.) -->
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
             <version>1.8.8-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
             <exclusions>
+                <!-- bungeecord-chat:1.8-SNAPSHOT no longer available in public repos -->
                 <exclusion>
                     <groupId>net.md-5</groupId>
                     <artifactId>bungeecord-chat</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
-
         <dependency>
             <groupId>de.leonkoth</groupId>
             <artifactId>blockparty-api</artifactId>
-            <version>${project.parent.version}</version>
             <scope>provided</scope>
         </dependency>
-
     </dependencies>
 
 </project>

--- a/spigot_v1_8_R3/pom.xml
+++ b/spigot_v1_8_R3/pom.xml
@@ -14,13 +14,8 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.7.0</version>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                    <encoding>UTF-8</encoding>
-                </configuration>
             </plugin>
         </plugins>
     </build>
@@ -42,6 +37,12 @@
             <artifactId>spigot-api</artifactId>
             <version>1.8.8-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>net.md-5</groupId>
+                    <artifactId>bungeecord-chat</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>de.leonkoth</groupId>
         <artifactId>blockparty-parent</artifactId>
-        <version>2.0.5-RELEASE</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -15,13 +15,8 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.7.0</version>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                    <encoding>UTF-8</encoding>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -83,7 +78,7 @@
             <groupId>org.eclipse.jetty.aggregate</groupId>
             <artifactId>jetty-all</artifactId>
             <version>9.4.15.v20190215</version>
-            <type>pom</type>
+            <classifier>uber</classifier>
             <scope>compile</scope>
         </dependency>
 

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -3,49 +3,52 @@
          xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>blockparty-parent</artifactId>
         <groupId>de.leonkoth</groupId>
+        <artifactId>blockparty-parent</artifactId>
         <version>2.0.5-RELEASE</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>blockparty-utils</artifactId>
-    <version>${project.parent.version}</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty.aggregate</groupId>
+            <artifactId>jetty-all</artifactId>
+            <classifier>uber</classifier>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>de.leonkoth</groupId>
+            <artifactId>blockparty-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
 
     <build>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.1</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
-                        <goals>
-                            <goal>shade</goal>
-                        </goals>
+                        <goals><goal>shade</goal></goals>
                         <configuration>
                             <filters>
                                 <filter>
                                     <artifact>*:*</artifact>
-                                    <excludes>
-                                        <exclude>META-INF/**</exclude>
-                                    </excludes>
-                                </filter>
-                                <filter>
-                                    <artifact>de.leonkoth:blockparty-*</artifact>
-                                    <includes>
-                                        <include>**</include>
-                                    </includes>
+                                    <excludes><exclude>META-INF/**</exclude></excludes>
                                 </filter>
                             </filters>
-
                             <minimizeJar>true</minimizeJar>
-
                             <createDependencyReducedPom>false</createDependencyReducedPom>
                         </configuration>
                     </execution>
@@ -53,52 +56,5 @@
             </plugin>
         </plugins>
     </build>
-    <packaging>jar</packaging>
-
-    <repositories>
-        <repository>
-            <id>spigot</id>
-            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
-        </repository>
-
-    </repositories>
-
-    <dependencies>
-
-        <!--Spigot API-->
-        <dependency>
-            <groupId>org.spigotmc</groupId>
-            <artifactId>spigot-api</artifactId>
-            <version>1.17-R0.1-SNAPSHOT</version>
-            <scope>provided</scope>
-        </dependency>
-
-        <!-- https://mvnrepository.com/artifact/org.eclipse.jetty.aggregate/jetty-all -->
-        <dependency>
-            <groupId>org.eclipse.jetty.aggregate</groupId>
-            <artifactId>jetty-all</artifactId>
-            <version>9.4.15.v20190215</version>
-            <classifier>uber</classifier>
-            <scope>compile</scope>
-        </dependency>
-
-        <!-- https://mvnrepository.com/artifact/com.google.code.findbugs/jsr305 -->
-        <dependency>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-            <version>3.0.2</version>
-            <scope>provided</scope>
-        </dependency>
-
-
-        <dependency>
-            <groupId>de.leonkoth</groupId>
-            <artifactId>blockparty-api</artifactId>
-            <version>${project.parent.version}</version>
-            <scope>provided</scope>
-        </dependency>
-
-
-    </dependencies>
 
 </project>

--- a/utils/src/main/java/de/pauhull/utils/locale/Locale.java
+++ b/utils/src/main/java/de/pauhull/utils/locale/Locale.java
@@ -2,7 +2,6 @@ package de.pauhull.utils.locale;
 
 import de.pauhull.utils.locale.storage.LocaleSection;
 import de.pauhull.utils.locale.storage.LocaleString;
-import de.pauhull.utils.misc.Reflection;
 import lombok.Getter;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -98,7 +97,7 @@ public abstract class Locale {
         }
 
         for (Field field : writeTo.getFields()) { // Write those strings to fields
-            if (Reflection.extendsFrom(LocaleString.class, field.getType())) {
+            if (LocaleString.class.isAssignableFrom(field.getType())) {
 
                 String name = convertName(field.getName());
                 if (strings.containsKey(name)) {

--- a/utils/src/main/java/de/pauhull/utils/message/type/ActionBarMessage.java
+++ b/utils/src/main/java/de/pauhull/utils/message/type/ActionBarMessage.java
@@ -1,9 +1,7 @@
 package de.pauhull.utils.message.type;
 
-import de.pauhull.utils.message.NMSClasses;
 import lombok.Getter;
 import net.md_5.bungee.api.ChatMessageType;
-import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.api.chat.TextComponent;
 import org.bukkit.entity.Player;
 
@@ -14,8 +12,6 @@ import org.bukkit.entity.Player;
  * @version 1.0
  */
 public class ActionBarMessage implements MessageType {
-
-    private static final boolean SPIGOT_ACTION_BAR;
 
     @Getter
     private String actionBar;
@@ -36,20 +32,6 @@ public class ActionBarMessage implements MessageType {
      */
     @Override
     public void send(Player player) {
-        if (SPIGOT_ACTION_BAR) {
-            player.spigot().sendMessage(ChatMessageType.ACTION_BAR, TextComponent.fromLegacyText(actionBar));
-        } else {
-            NMSClasses.sendActionBarNMS(player, actionBar);
-        }
-    }
-
-    static {
-        boolean actionBar = false;
-        try {
-            Class<?> messageType = Class.forName("net.md_5.bungee.api.ChatMessageType");
-            Class.forName("org.bukkit.entity.Player$Spigot").getMethod("sendMessage", messageType, BaseComponent[].class);
-            actionBar = true;
-        } catch (ClassNotFoundException | NoSuchMethodException ignored) {}
-        SPIGOT_ACTION_BAR = actionBar;
+        player.spigot().sendMessage(ChatMessageType.ACTION_BAR, TextComponent.fromLegacyText(actionBar));
     }
 }

--- a/utils/src/main/java/de/pauhull/utils/message/type/TitleMessage.java
+++ b/utils/src/main/java/de/pauhull/utils/message/type/TitleMessage.java
@@ -1,6 +1,5 @@
 package de.pauhull.utils.message.type;
 
-import de.pauhull.utils.message.NMSClasses;
 import lombok.Getter;
 import org.bukkit.entity.Player;
 
@@ -11,8 +10,6 @@ import org.bukkit.entity.Player;
  * @version 1.0
  */
 public class TitleMessage implements MessageType {
-
-    private static final boolean SEND_TITLE;
 
     @Getter
     private String title;
@@ -47,19 +44,6 @@ public class TitleMessage implements MessageType {
      */
     @Override
     public void send(Player player) {
-        if (SEND_TITLE) {
-            player.sendTitle(title, subTitle, fadeIn, stay, fadeOut);
-        } else {
-            NMSClasses.sendTitlesNMS(player, title, subTitle, fadeIn, stay, fadeOut);
-        }
-    }
-
-    static {
-        boolean sendTitle = false;
-        try {
-            Player.class.getMethod("sendTitle", String.class, String.class, int.class, int.class, int.class);
-            sendTitle = true;
-        } catch (NoSuchMethodException ignored) {}
-        SEND_TITLE = sendTitle;
+        player.sendTitle(title, subTitle, fadeIn, stay, fadeOut);
     }
 }

--- a/utils/src/main/java/de/pauhull/utils/misc/CommandUtils.java
+++ b/utils/src/main/java/de/pauhull/utils/misc/CommandUtils.java
@@ -28,7 +28,7 @@ public class CommandUtils {
                 Field knownCommands = map.getClass().getDeclaredField("knownCommands");
                 knownCommands.setAccessible(true);
 
-                Map<String, Command> commands = (Map<String, Command>) knownCommands.get(map);
+                Map<String, Command> commands = getKnownCommands(knownCommands, map);
 
                 for (String name : commands.keySet()) {
                     for (String checkName : commandsToUnregister) {
@@ -46,6 +46,11 @@ public class CommandUtils {
             }
 
         }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Command> getKnownCommands(Field knownCommands, SimpleCommandMap map) throws IllegalAccessException {
+        return (Map<String, Command>) knownCommands.get(map);
     }
 
 }

--- a/utils/src/main/java/de/pauhull/utils/misc/ItemBuilder.java
+++ b/utils/src/main/java/de/pauhull/utils/misc/ItemBuilder.java
@@ -1,6 +1,5 @@
 package de.pauhull.utils.misc;
 
-import de.leonkoth.blockparty.version.VersionHandler;
 import de.leonkoth.blockparty.version.VersionedMaterial;
 import lombok.Getter;
 import lombok.ToString;
@@ -12,9 +11,6 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.LeatherArmorMeta;
 import org.bukkit.inventory.meta.SkullMeta;
-import org.bukkit.potion.Potion;
-import org.bukkit.potion.PotionType;
-
 import java.util.Arrays;
 import java.util.List;
 

--- a/utils/src/main/java/de/pauhull/utils/misc/MinecraftVersion.java
+++ b/utils/src/main/java/de/pauhull/utils/misc/MinecraftVersion.java
@@ -155,11 +155,10 @@ public class MinecraftVersion {
      */
     public MinecraftVersion() {
         String[] split = Bukkit.getBukkitVersion().split("-")[0].split("\\.");
-        String pack = Bukkit.getServer().getClass().getPackage().getName();
-        this.version = pack.substring(pack.lastIndexOf('.') + 1);
         this.major = 1;
         this.minor = Integer.parseInt(split[1]);
         this.patch = split.length > 2 ? Integer.parseInt(split[2]) : 0;
+        this.version = this.minor >= 21 ? "v1_21_R1" : "v1_20_R1";
     }
 
     /**

--- a/utils/src/main/java/de/pauhull/utils/misc/MinecraftVersion.java
+++ b/utils/src/main/java/de/pauhull/utils/misc/MinecraftVersion.java
@@ -17,6 +17,22 @@ public class MinecraftVersion {
     public static final MinecraftVersion CURRENT_VERSION = new MinecraftVersion();
 
     //region VERSIONS
+    public static final MinecraftVersion v1_21_4 = new MinecraftVersion(1, 21, 4, "v1_21_R1");
+    public static final MinecraftVersion v1_21_1 = new MinecraftVersion(1, 21, 1, "v1_21_R1");
+    public static final MinecraftVersion v1_21 = new MinecraftVersion(1, 21, "v1_21_R1");
+    public static final MinecraftVersion v1_20_6 = new MinecraftVersion(1, 20, 6, "v1_20_R4");
+    public static final MinecraftVersion v1_20_4 = new MinecraftVersion(1, 20, 4, "v1_20_R3");
+    public static final MinecraftVersion v1_20_2 = new MinecraftVersion(1, 20, 2, "v1_20_R2");
+    public static final MinecraftVersion v1_20_1 = new MinecraftVersion(1, 20, 1, "v1_20_R1");
+    public static final MinecraftVersion v1_20 = new MinecraftVersion(1, 20, "v1_20_R1");
+    public static final MinecraftVersion v1_19_4 = new MinecraftVersion(1, 19, 4, "v1_19_R3");
+    public static final MinecraftVersion v1_19_3 = new MinecraftVersion(1, 19, 3, "v1_19_R3");
+    public static final MinecraftVersion v1_19_2 = new MinecraftVersion(1, 19, 2, "v1_19_R2");
+    public static final MinecraftVersion v1_19_1 = new MinecraftVersion(1, 19, 1, "v1_19_R1");
+    public static final MinecraftVersion v1_19 = new MinecraftVersion(1, 19, "v1_19_R1");
+    public static final MinecraftVersion v1_18_2 = new MinecraftVersion(1, 18, 2, "v1_18_R2");
+    public static final MinecraftVersion v1_18_1 = new MinecraftVersion(1, 18, 1, "v1_18_R1");
+    public static final MinecraftVersion v1_18 = new MinecraftVersion(1, 18, "v1_18_R1");
     public static final MinecraftVersion v1_17 = new MinecraftVersion(1, 17, "v1_17_R1");
     public static final MinecraftVersion v1_16_5 = new MinecraftVersion(1, 16, 5, "v1_16_R3");
     public static final MinecraftVersion v1_16_4 = new MinecraftVersion(1, 16, 4, "v1_16_R3");
@@ -71,6 +87,16 @@ public class MinecraftVersion {
     public static List<MinecraftVersion> versionList = new ArrayList<>();
 
     static {
+        versionList.add(v1_21);
+        versionList.add(v1_20_4);
+        versionList.add(v1_20);
+        versionList.add(v1_19_3);
+        versionList.add(v1_19);
+        versionList.add(v1_18_2);
+        versionList.add(v1_18);
+        versionList.add(v1_16_5);
+        versionList.add(v1_16_1);
+        versionList.add(v1_15);
         versionList.add(v1_14);
         versionList.add(v1_13_1);
         versionList.add(v1_13);

--- a/utils/src/main/java/de/pauhull/utils/misc/RandomFireworkGenerator.java
+++ b/utils/src/main/java/de/pauhull/utils/misc/RandomFireworkGenerator.java
@@ -31,7 +31,7 @@ public class RandomFireworkGenerator {
         if (amount < 1)
             return;
 
-        Firework firework = (Firework) location.getWorld().spawnEntity(location, EntityType.FIREWORK);
+        Firework firework = (Firework) location.getWorld().spawnEntity(location, EntityType.FIREWORK_ROCKET);
         FireworkMeta meta = firework.getFireworkMeta();
 
         FireworkEffect.Type type = getRandomFireworkEffectType();

--- a/utils/src/main/java/de/pauhull/utils/particle/BukkitParticlePlayer.java
+++ b/utils/src/main/java/de/pauhull/utils/particle/BukkitParticlePlayer.java
@@ -32,8 +32,8 @@ class BukkitParticlePlayer implements ParticlePlayer {
         switch (particles) {
             case CLOUD: return Particle.CLOUD;
             case CRIT: return Particle.CRIT;
-            case EXPLOSION_NORMAL: return Particle.EXPLOSION_NORMAL;
-            case SPELL: return Particle.SPELL;
+            case EXPLOSION_NORMAL: return Particle.EXPLOSION;
+            case SPELL: return Particle.EFFECT;
             default: throw new IllegalArgumentException("Unknown particle");
         }
     }

--- a/utils/src/main/java/de/pauhull/utils/particle/ParticlePlayerProvider.java
+++ b/utils/src/main/java/de/pauhull/utils/particle/ParticlePlayerProvider.java
@@ -1,25 +1,10 @@
 package de.pauhull.utils.particle;
 
-import org.bukkit.Location;
-import org.bukkit.entity.Player;
-
 public final class ParticlePlayerProvider {
-
-    private static final boolean PARTICLE_API;
 
     private ParticlePlayerProvider() {}
 
     public static ParticlePlayer get(Particles particles) {
-        return PARTICLE_API ? new BukkitParticlePlayer(particles) : new NmsParticlePlayer(particles);
-    }
-
-    static {
-        boolean particle = false;
-        try {
-            Class<?> particleClass = Class.forName("org.bukkit.Particle");
-            Player.class.getMethod("spawnParticle", particleClass, Location.class, int.class);
-            particle = true;
-        } catch (NoSuchMethodException | ClassNotFoundException ignored) {}
-        PARTICLE_API = particle;
+        return new BukkitParticlePlayer(particles);
     }
 }


### PR DESCRIPTION
chore: update deps

chore: cleanup maven

feat: add multi-version Spigot support by modularizing modules and updating version handling logic

chore: update .gitignore

feat: add 1.20.6 support, remove legacy material data handling, and update particle mappings

refactor: modernize codebase with generics, improved reflection, and updated Bukkit API usage while removing deprecated inventory updates.