### PR TITLE
ci: add git hooks and align CI with them

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+#
+# commit-msg hook: enforce Conventional Commits so history stays clean and CI's
+# commit-lint job never rejects what was already committed locally.
+#
+# Bypass (discouraged):  git commit --no-verify
+
+exec "$(git rev-parse --show-toplevel)/scripts/lint-commit-msg.sh" "$1"

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,38 @@
+#!/usr/bin/env sh
+#
+# pre-commit hook: fast, purely textual guards so the commit loop stays instant.
+# Anything that needs a JVM (compile/tests) runs in pre-push instead.
+#
+# Bypass (discouraged):  git commit --no-verify
+
+set -eu
+
+# Nothing staged yet (e.g. initial commit) -> let git handle it.
+if git rev-parse --verify HEAD >/dev/null 2>&1; then
+  against=HEAD
+else
+  against=$(git hash-object -t tree /dev/null)
+fi
+
+status=0
+
+# 1. Unresolved merge-conflict markers and whitespace errors on staged content.
+if ! git diff --cached --check "$against" --; then
+  echo "✖ Fix the whitespace errors / conflict markers above before committing." >&2
+  status=1
+fi
+
+# 2. Guard against accidentally committing large binaries (>5 MiB).
+max_bytes=$((5 * 1024 * 1024))
+while IFS= read -r file; do
+  [ -f "$file" ] || continue
+  size=$(git cat-file -s ":$file" 2>/dev/null || echo 0)
+  if [ "$size" -gt "$max_bytes" ]; then
+    echo "✖ $file is $((size / 1024 / 1024)) MiB (>5 MiB). Commit with --no-verify if intentional." >&2
+    status=1
+  fi
+done <<EOF
+$(git diff --cached --name-only --diff-filter=ACM)
+EOF
+
+exit $status

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,35 @@
+#!/usr/bin/env sh
+#
+# pre-push hook: run the same build CI runs, so red never reaches the remote and
+# the required "build" status check passes on the first try.
+#
+# Bypass (discouraged):  git push --no-verify
+# Skip once:             SKIP_HOOKS=1 git push
+
+set -eu
+
+if [ "${SKIP_HOOKS:-}" = "1" ]; then
+  echo "pre-push: SKIP_HOOKS=1 set — skipping build." >&2
+  exit 0
+fi
+
+# Only build when we are actually pushing commits (skip branch/tag deletions).
+pushing=0
+while read -r _local_ref local_sha _remote_ref _remote_sha; do
+  case "$local_sha" in
+    0000000000000000000000000000000000000000|"") ;; # deletion / no ref
+    *) pushing=1 ;;
+  esac
+done
+[ "$pushing" -eq 1 ] || exit 0
+
+root=$(git rev-parse --show-toplevel)
+
+if ! command -v mvn >/dev/null 2>&1; then
+  echo "✖ pre-push: 'mvn' not found on PATH. Install Maven or push with --no-verify." >&2
+  exit 1
+fi
+
+echo "pre-push: running 'mvn clean verify' (bypass with 'git push --no-verify')…" >&2
+# -T1C parallelises the reactor across cores; mirrors the CI command.
+mvn -B --no-transfer-progress -T1C clean verify --file "$root/pom.xml"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,31 +1,74 @@
-name: Build
+name: CI
 
 on:
   push:
     branches: [ "main", "v3" ]
+    # Docs-only pushes don't affect the build. (Not applied to pull_request /
+    # merge_group: "build" is a required check there and must always report.)
+    paths-ignore: [ "**/*.md", "docs/**", ".githooks/**" ]
   pull_request:
     branches: [ "main", "v3" ]
+  merge_group:
+    branches: [ "main", "v3" ]
+
+# Cancel superseded runs for the same ref (merge-queue refs are unique, so
+# queued entries are never cancelled).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# Least privilege: the build only needs to read the repo.
+permissions:
+  contents: read
 
 jobs:
-  build:
+  # Fast gate — reuses the exact script the local commit-msg hook runs, so the
+  # rule has a single source of truth and is enforced even if hooks are bypassed.
+  commit-lint:
+    name: Commit messages
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-
+    timeout-minutes: 5
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+      - name: Validate Conventional Commits
+        run: |
+          base='${{ github.event.pull_request.base.sha }}'
+          head='${{ github.event.pull_request.head.sha }}'
+          status=0
+          for sha in $(git rev-list --no-merges "$base..$head"); do
+            git log -1 --format=%B "$sha" | ./scripts/lint-commit-msg.sh - || status=1
+          done
+          exit $status
 
-    - name: Set up JDK 21
-      uses: actions/setup-java@v4
-      with:
-        java-version: '21'
-        distribution: 'temurin'
-        cache: 'maven'
+  build:
+    name: Build & test
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
 
-    - name: Build and test with Maven
-      run: mvn -B clean verify --file pom.xml
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'maven'
 
-    - name: Upload Artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: blockparty-plugin
-        path: target/BlockParty-*.jar
-        retention-days: 14
+      # Same command as the pre-push hook: -T1C parallelises the reactor,
+      # --no-transfer-progress trims download noise from the logs.
+      - name: Build and test with Maven
+        run: mvn -B --no-transfer-progress -T1C clean verify --file pom.xml
+
+      # The distributable jar is only worth keeping for real branch builds /
+      # merge-queue runs — skip it on PRs to keep feedback fast.
+      - name: Upload Artifact
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: blockparty-plugin
+          path: target/BlockParty-*.jar
+          retention-days: 14

--- a/README.md
+++ b/README.md
@@ -16,6 +16,40 @@ See [COMPATIBILITY.md](COMPATIBILITY.md) for the runtime matrix and release spli
 Download the jar file and place it into your plugins folder. A new folder is created (named BlockParty) after the server is started.
 A few file and sub-folders should be located there.
 
+## Building from source
+
+Requires JDK 21 and Maven.
+
+```bash
+mvn clean verify
+```
+
+The distributable plugin jar is produced at `target/BlockParty-<version>.jar`.
+
+## Development
+
+Git hooks are versioned in [`.githooks/`](.githooks) and install themselves on your
+**first Maven build** (`mvn` sets `core.hooksPath` via the `git-build-hook` plugin).
+To enable them without building, run once:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+| Hook         | When         | What it does                                                            |
+|--------------|--------------|-------------------------------------------------------------------------|
+| `pre-commit` | `git commit` | Blocks conflict markers, whitespace errors, and >5 MiB files (instant). |
+| `commit-msg` | `git commit` | Enforces [Conventional Commits](https://www.conventionalcommits.org).   |
+| `pre-push`   | `git push`   | Runs `mvn clean verify` so red never reaches the remote.                |
+
+The `commit-msg` rule is defined once in [`scripts/lint-commit-msg.sh`](scripts/lint-commit-msg.sh)
+and reused by CI's `commit-lint` job, so local and CI checks can never drift apart.
+Allowed types: `feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert, security`.
+
+Bypass a hook only when you must: `git commit --no-verify`, `git push --no-verify`
+(or `SKIP_HOOKS=1 git push`). CI re-checks everything regardless, and the `build`
+status check must be green before a PR can merge.
+
 ## Configuration
 
 #### config.yml

--- a/pom.xml
+++ b/pom.xml
@@ -139,6 +139,31 @@
     </dependencies>
 
     <build>
+        <plugins>
+            <!-- Point git at the versioned .githooks/ dir on the first build so every
+                 contributor gets the pre-commit / commit-msg / pre-push hooks with no
+                 manual setup. inherited=false keeps it on the aggregator only. -->
+            <plugin>
+                <groupId>com.rudikershaw.gitbuildhook</groupId>
+                <artifactId>git-build-hook-maven-plugin</artifactId>
+                <version>3.6.0</version>
+                <inherited>false</inherited>
+                <configuration>
+                    <gitConfig>
+                        <core.hooksPath>.githooks/</core.hooksPath>
+                    </gitConfig>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>configure</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+
         <pluginManagement>
             <plugins>
                 <plugin>

--- a/scripts/lint-commit-msg.sh
+++ b/scripts/lint-commit-msg.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env sh
+#
+# Validate a commit message against the Conventional Commits format.
+# Single source of truth shared by the .githooks/commit-msg hook and CI.
+#
+# Usage:
+#   scripts/lint-commit-msg.sh <path-to-message-file>
+#   <something> | scripts/lint-commit-msg.sh -      # read message from stdin
+#
+# Exit status is 0 when the message is valid, 1 otherwise.
+
+set -eu
+
+# Allowed commit types (Conventional Commits + this repo's "security" type).
+TYPES='feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert|security'
+MAX_SUBJECT_LEN=100
+
+# --- read the message -------------------------------------------------------
+if [ "$#" -lt 1 ]; then
+  echo "lint-commit-msg: missing argument (message file or '-')" >&2
+  exit 2
+fi
+
+if [ "$1" = "-" ]; then
+  msg=$(cat)
+else
+  msg=$(cat "$1")
+fi
+
+# First non-empty, non-comment line is the subject.
+subject=$(printf '%s\n' "$msg" | grep -v '^#' | sed '/^[[:space:]]*$/d' | head -n1)
+
+# --- skip messages that git generates or that are conventionally exempt -----
+case "$subject" in
+  "Merge "*|"Revert "*|"fixup! "*|"squash! "*|"amend! "*)
+    exit 0
+    ;;
+esac
+
+fail() {
+  echo "✖ Invalid commit message:" >&2
+  echo "    $subject" >&2
+  echo "" >&2
+  echo "  $1" >&2
+  echo "" >&2
+  echo "  Expected: <type>(optional-scope): <description>" >&2
+  echo "  Types:    ${TYPES}" >&2
+  echo "  Examples: feat(core): add round timer" >&2
+  echo "            fix: prevent NPE on reload" >&2
+  echo "            security!: rotate leaked token" >&2
+  exit 1
+}
+
+[ -n "$subject" ] || fail "commit message is empty"
+
+# <type>(scope)?!?: description
+if ! printf '%s' "$subject" | grep -Eq "^(${TYPES})(\([a-z0-9._/-]+\))?!?: .+"; then
+  fail "subject does not match the Conventional Commits format"
+fi
+
+len=$(printf '%s' "$subject" | wc -c | tr -d ' ')
+if [ "$len" -gt "$MAX_SUBJECT_LEN" ]; then
+  fail "subject is ${len} chars; keep it under ${MAX_SUBJECT_LEN}"
+fi
+
+exit 0


### PR DESCRIPTION
Optimizes the dev workflow with versioned git hooks and pairs the GitHub Action with them.

## Git hooks (`.githooks/`, auto-installing)
Installed automatically on the first `mvn` build via the `git-build-hook` plugin (sets `core.hooksPath`); or `git config core.hooksPath .githooks`.

| Hook | Cost | Guards |
|------|------|--------|
| `pre-commit` | instant | conflict markers, whitespace errors, >5 MiB files |
| `commit-msg` | instant | Conventional Commits |
| `pre-push` | full build | `mvn clean verify` before pushing |

## Shared rule
`scripts/lint-commit-msg.sh` is the single source of truth for the commit-message rule — used by both the `commit-msg` hook and CI's new `commit-lint` job, so local and CI checks can't drift.

## CI optimizations (`.github/workflows/build.yml`)
- New fast `commit-lint` job (PRs) reusing the shared script
- Parallel Maven build (`-T1C`) + `--no-transfer-progress`; identical command in `pre-push` and CI
- `permissions: contents: read`, job `timeout-minutes`
- Artifact upload skipped on PRs; docs-only push filter (not on PRs/merge_group, so the required `build` check always reports)

## Notes
- README gains *Building from source* + *Development* sections.
- The sandbox where this was authored has no JVM, so the local `mvn verify` wasn't run — **CI runs the real build on this PR**. Please confirm it's green before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)